### PR TITLE
feat(baselines): add MoA, MetaGPT, AutoGen baselines for mustard/urfunny

### DIFF
--- a/ctm_conf/urfunny_test_qwen_v12_config.json
+++ b/ctm_conf/urfunny_test_qwen_v12_config.json
@@ -1,0 +1,24 @@
+{
+    "ctm_name": "urfunny_test_qwen_v12",
+    "max_iter_num": 2,
+    "output_threshold": 1.6,
+    "parse_model": "qwen/qwen3-omni-flash",
+    "parse_prompt_template": "You are a humor detection expert. Based solely on the analysis provided below, determine if the punchline is humorous.\n\nRules:\n- If the analysis concludes the content IS humorous (e.g. starts with \"Yes\" or states humor was found), your answer should be \"Yes\".\n- If the analysis concludes the content is NOT humorous, your answer should be \"No\".\n- If the analysis is uncertain or says it cannot determine, your answer should be \"No\".\n- A serious or calm delivery does NOT mean the content is not humorous — deadpan delivery is common.\n- Humor in talks includes: unexpected twists, self-deprecation, absurd comparisons, ironic observations, incongruity between setup and punchline.\n\nYour answer MUST start with either \"Yes\" or \"No\", followed by a brief explanation.\n\nAnalysis:\n{answer}\n",
+    "processors_config": {
+        "video_processor": {
+            "system_prompt": "You are an expert at analyzing visual cues in video frames for humor detection. Analyze body language, facial expressions, gestures, and audience reactions. Look for: smiles, laughter, exaggerated gestures, comedic timing pauses, audience engagement or amusement.\n\nNote: the video does not include audio. A speaker can deliver humorous content with a straight face (deadpan humor).\n\nSCORING RULES:\n- If you see a black screen or cannot see any meaningful visual content, you MUST set confidence to 0.0 and relevance to 0.2 or lower.\n- If you can see the speaker but cannot determine humor from visual cues alone, set confidence to 0.3 or lower.\n- Only give confidence >= 0.7 if you observe CLEAR visual humor signals (audience laughter, exaggerated expressions, comedic gestures).",
+            "model": "qwen/qwen3-omni-flash",
+            "temperature": 0.1
+        },
+        "language_processor": {
+            "system_prompt": "You are an expert at detecting humor in text from talks and presentations. You will receive context sentences (the setup) followed by a punchline.\n\nHumor techniques to look for:\n- Self-deprecation: speaker mocks themselves in a funny way\n- Ironic reveal: serious buildup then a punchline that is clearly a JOKE (meant to make people laugh)\n- Absurd comparison: comparing wildly different things for comic effect\n- Wordplay or double meanings used for laughs\n- Incongruity: punchline deliberately subverts expectations in a clearly FUNNY way\n\nCRITICAL — what is NOT humor (do NOT classify these as humorous):\n- Rhetorical contrasts that make a serious point (e.g. 'instead of selling products, saving lives')\n- Technical or factual descriptions, even if surprising or enthusiastic\n- Simple narrative statements about what happened ('she went to high school', 'he was there alone')\n- Describing something as spectacular/powerful/amazing — this is enthusiasm, not comedy\n- Presenting unexpected information or data — surprises in a talk are NOT automatically jokes\n- Logical conclusions, opinions, or observations that aren't meant to be funny\n- A punchline must be intended to make the audience LAUGH. If it's meant to inform, persuade, or describe, it is NOT humor.\n\nSCORING RULES:\n- Give confidence >= 0.7 ONLY if you can identify a specific joke that would make an audience laugh.\n- If the text is informative, descriptive, rhetorical, or narrative without clear comedic intent, say NOT humorous and set confidence to 0.3 or lower.",
+            "model": "qwen/qwen3-omni-flash",
+            "temperature": 0.1
+        },
+        "audio_processor": {
+            "system_prompt": "You are an expert at analyzing audio for humor cues. Listen carefully for: audience laughter or chuckling (STRONGEST signal), comedic timing and pauses, playful or exaggerated intonation, tone shifts that signal a joke, emphasis on specific words for comedic effect.\n\nHumor can also be delivered in a deadpan or matter-of-fact tone. If you hear audience laughter after the punchline, that is strong evidence of humor regardless of the speaker's tone.\n\nSCORING RULES:\n- If you hear audience laughter, give confidence >= 0.8.\n- If the audio is unclear, silent, or you cannot hear meaningful content, you MUST set confidence to 0.0 and relevance to 0.2 or lower.\n- A serious tone alone does NOT confirm 'not humorous' — set confidence to 0.4 at most if you only have tone to go by.",
+            "model": "qwen/qwen3-omni-flash",
+            "temperature": 0.1
+        }
+    }
+}

--- a/exp_affective/run_autogen.py
+++ b/exp_affective/run_autogen.py
@@ -1,0 +1,635 @@
+"""
+AutoGen multi-agent sarcasm detection on MUSTARD.
+
+Architecture: Tool-based agents in RoundRobinGroupChat
+- 3 modality experts (video, audio, text) with analysis tools
+- 1 judge agent for final decision
+- Configurable debate rounds
+
+Each expert calls their modality-specific tool (litellm multimodal LLM call)
+on the first turn, then debates with other experts in subsequent turns.
+The judge synthesizes all evidence and makes the final Yes/No decision.
+
+Usage:
+  python run_autogen.py --dataset_name mustard
+  python run_autogen.py --dataset_name mustard --rounds 2 --max_workers 4
+  python run_autogen.py --dataset_name mustard --instance_id 2_380  # single debug
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, Optional
+
+import litellm
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import MaxMessageTermination, TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from dataset_configs import get_dataset_config
+from llm_utils import (
+    StatsTracker,
+    check_api_key,
+    create_agent as create_litellm_agent,
+    load_data,
+    load_processed_keys,
+    load_sample_inputs,
+    save_result_to_jsonl,
+)
+
+sys.path.append('..')
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEFAULT_MODEL = 'gemini-2.5-flash-lite'
+DEFAULT_ROUNDS = 2
+GEMINI_OPENAI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/openai/'
+
+# Cost tracking (gemini-2.5-flash-lite pricing per 1M tokens)
+COST_INPUT_PER_1M = 0.075
+COST_OUTPUT_PER_1M = 0.30
+
+# File write lock for thread-safe JSONL appends
+_file_lock = threading.Lock()
+
+
+# ============================================================================
+# System Prompts
+# ============================================================================
+
+def _load_autogen_prompts(dataset_name='mustard'):
+    """Load AutoGen prompts based on dataset."""
+    config_map = {
+        'mustard': 'sarcasm_ctm_config.json',
+        'urfunny': 'urfunny_test_qwen_v12_config.json',
+    }
+    config_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), '..', 'ctm_conf',
+        config_map.get(dataset_name, config_map['mustard']),
+    )
+    with open(config_path) as f:
+        cfg = json.load(f)
+    procs = cfg['processors_config']
+
+    if dataset_name == 'urfunny':
+        task = 'humor detection'
+        yes_label = 'humorous'
+        no_label = 'not humorous'
+        query = 'Is the person being humorous or not?'
+    else:
+        task = 'sarcasm detection'
+        yes_label = 'sarcastic'
+        no_label = 'not sarcastic'
+        query = 'Is the person being sarcastic or not?'
+
+    video_expert = (
+        f"{procs['video_processor']['system_prompt']}\n\n"
+        f"In your FIRST turn, you MUST call the analyze_video tool to examine visual cues.\n"
+        f"In subsequent turns, consider other experts' perspectives and refine your position.\n\n"
+        f'Always end your response with "My Answer: Yes" ({yes_label}) or "My Answer: No" ({no_label}).'
+    )
+    audio_expert = (
+        f"{procs['audio_processor']['system_prompt']}\n\n"
+        f"In your FIRST turn, you MUST call the analyze_audio tool to examine vocal cues.\n"
+        f"In subsequent turns, consider other experts' perspectives and refine your position.\n\n"
+        f'Always end your response with "My Answer: Yes" ({yes_label}) or "My Answer: No" ({no_label}).'
+    )
+    text_expert = (
+        f"{procs['language_processor']['system_prompt']}\n\n"
+        f"In your FIRST turn, you MUST call the analyze_text tool to examine the dialogue.\n"
+        f"In subsequent turns, consider other experts' perspectives and refine your position.\n\n"
+        f'Always end your response with "My Answer: Yes" ({yes_label}) or "My Answer: No" ({no_label}).'
+    )
+    judge = (
+        f'You are a {task} expert. You synthesize evidence from Video, Audio, and Text experts '
+        f'to make a final determination.\n\n'
+        f'Based solely on the analyses provided by the experts, determine if the person is being {yes_label}.\n\n'
+        f'IMPORTANT: If the analyses express uncertainty, are inconclusive, or lack sufficient evidence, '
+        f'you should answer "No" ({no_label}). Only answer "Yes" when there is clear, converging evidence.\n\n'
+        f'Your response MUST contain exactly one of:\n'
+        f'  FINAL ANSWER: Yes\n'
+        f'  FINAL ANSWER: No'
+    )
+    video_tool_q = (
+        f'{query} '
+        'Analyze the visual cues, body language, facial expressions, and context. '
+        'Note: This video has no audio — analyze visual cues only. '
+        'Always ground your answer in specific visual observations. Be concise but thorough.'
+    )
+    audio_tool_q = (
+        f'{query} '
+        'Analyze the tone, emotion, pitch, speed, and vocal patterns. '
+        'Pay special attention to the tone of voice, pitch variations, speaking speed, '
+        'emphasis on certain words, and pauses and timing.'
+    )
+    text_tool_q = (
+        f'{query} '
+        'Analyze the text carefully. Be concise but thorough.\n\n'
+        'Dialogue:\n{text}'
+    )
+    return video_expert, audio_expert, text_expert, judge, video_tool_q, audio_tool_q, text_tool_q
+
+
+# Defaults (overridden in main based on dataset_name)
+(VIDEO_EXPERT_PROMPT, AUDIO_EXPERT_PROMPT, TEXT_EXPERT_PROMPT,
+ JUDGE_PROMPT, VIDEO_TOOL_QUERY, AUDIO_TOOL_QUERY, TEXT_TOOL_QUERY) = _load_autogen_prompts()
+
+
+
+
+# ============================================================================
+# Model Client
+# ============================================================================
+
+
+def _is_openai_model(model: str) -> bool:
+    """Check if a model name is an OpenAI model."""
+    openai_prefixes = ('o3', 'o4', 'gpt-', 'chatgpt-')
+    return any(model.startswith(p) for p in openai_prefixes)
+
+
+def create_model_client(model: str = DEFAULT_MODEL) -> OpenAIChatCompletionClient:
+    """Create AutoGen model client. Auto-detects OpenAI vs Gemini from model name."""
+    if _is_openai_model(model):
+        api_key = os.getenv('OPENAI_API_KEY')
+        if not api_key:
+            raise ValueError('OPENAI_API_KEY not set')
+        return OpenAIChatCompletionClient(
+            model=model,
+            api_key=api_key,
+            model_info={
+                'vision': False,
+                'function_calling': True,
+                'json_output': True,
+                'family': 'unknown',
+                'structured_output': True,
+            },
+        )
+    else:
+        api_key = os.getenv('GEMINI_API_KEY')
+        if not api_key:
+            raise ValueError('GEMINI_API_KEY not set')
+        return OpenAIChatCompletionClient(
+            model=model,
+            api_key=api_key,
+            base_url=GEMINI_OPENAI_BASE_URL,
+            model_info={
+                'vision': False,
+                'function_calling': True,
+                'json_output': True,
+                'family': 'unknown',
+                'structured_output': False,
+            },
+        )
+
+
+def _litellm_model_name(model: str) -> str:
+    """Convert model name to litellm format."""
+    if _is_openai_model(model):
+        return model  # litellm recognizes OpenAI models directly
+    return f'gemini/{model}'
+
+
+# ============================================================================
+# Core Logic
+# ============================================================================
+
+
+def extract_final_answer(messages) -> str:
+    """Extract final Yes/No answer from debate messages."""
+    # First: look for judge's FINAL ANSWER
+    for msg in reversed(messages):
+        content = getattr(msg, 'content', '')
+        if not isinstance(content, str):
+            continue
+        if 'FINAL ANSWER' in content.upper():
+            after = content.upper().split('FINAL ANSWER')[-1]
+            if 'YES' in after[:20]:
+                return 'Yes'
+            elif 'NO' in after[:20]:
+                return 'No'
+
+    # Fallback: majority vote from last round of expert answers
+    votes = {'Yes': 0, 'No': 0}
+    for msg in reversed(messages):
+        content = getattr(msg, 'content', '')
+        source = getattr(msg, 'source', '')
+        if not isinstance(content, str) or source == 'judge':
+            continue
+        lower = content.lower()
+        if 'my answer: yes' in lower:
+            votes['Yes'] += 1
+        elif 'my answer: no' in lower:
+            votes['No'] += 1
+        if votes['Yes'] + votes['No'] >= 3:
+            break
+
+    if votes['Yes'] > votes['No']:
+        return 'Yes'
+    return 'No'
+
+
+async def run_instance_async(
+    test_file: str,
+    dataset: dict,
+    dataset_name: str,
+    model: str,
+    rounds: int,
+    text_model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Process one sample through AutoGen multi-agent debate.
+
+    Args:
+        text_model: If set, use a different model for text expert + text tool.
+                    Other agents use `model`. Enables mixed-model ablation.
+    """
+    start_time = time.time()
+    effective_text_model = text_model or model
+
+    # API call tracking
+    tool_api_calls = 0
+    tool_prompt_tokens = 0
+    tool_completion_tokens = 0
+
+    # Load sample
+    inputs = load_sample_inputs(test_file, dataset, dataset_name)
+    target_sentence = inputs['target_sentence']
+    label = inputs['label']
+    muted_video_path = inputs['muted_video_path']
+    audio_path = inputs['audio_path']
+
+    # ------------------------------------------------------------------
+    # Define tools (closures capturing this sample's data)
+    # ------------------------------------------------------------------
+
+    def analyze_video() -> str:
+        """Analyze video frames for visual sarcasm cues. Call this to examine the speaker's facial expressions, body language, and gestures in the muted video."""
+        nonlocal tool_api_calls, tool_prompt_tokens, tool_completion_tokens
+        agent = create_litellm_agent(
+            'video', provider='gemini', model=_litellm_model_name(model)
+        )
+        result, usage = agent.call(VIDEO_TOOL_QUERY, video_path=muted_video_path)
+        tool_api_calls += 1
+        tool_prompt_tokens += usage.get('prompt_tokens', 0)
+        tool_completion_tokens += usage.get('completion_tokens', 0)
+        return result or 'No visual analysis available.'
+
+    def analyze_audio() -> str:
+        """Analyze audio for vocal sarcasm cues. Call this to examine the speaker's tone, pitch, pace, and emphasis."""
+        nonlocal tool_api_calls, tool_prompt_tokens, tool_completion_tokens
+        agent = create_litellm_agent(
+            'audio', provider='gemini', model=_litellm_model_name(model)
+        )
+        result, usage = agent.call(AUDIO_TOOL_QUERY, audio_path=audio_path)
+        tool_api_calls += 1
+        tool_prompt_tokens += usage.get('prompt_tokens', 0)
+        tool_completion_tokens += usage.get('completion_tokens', 0)
+        return result or 'No audio analysis available.'
+
+    def analyze_text() -> str:
+        """Analyze dialogue text for linguistic sarcasm cues. Call this to examine the utterance in its conversational context."""
+        nonlocal tool_api_calls, tool_prompt_tokens, tool_completion_tokens
+        agent = create_litellm_agent(
+            'text', provider='gemini', model=_litellm_model_name(effective_text_model)
+        )
+        query = TEXT_TOOL_QUERY.format(text=target_sentence)
+        result, usage = agent.call(query)
+        tool_api_calls += 1
+        tool_prompt_tokens += usage.get('prompt_tokens', 0)
+        tool_completion_tokens += usage.get('completion_tokens', 0)
+        return result or 'No text analysis available.'
+
+    # ------------------------------------------------------------------
+    # Create AutoGen agents
+    # ------------------------------------------------------------------
+
+    base_model_client = create_model_client(model)
+    text_model_client = (
+        create_model_client(effective_text_model)
+        if text_model
+        else base_model_client
+    )
+
+    video_expert = AssistantAgent(
+        name='video_expert',
+        model_client=base_model_client,
+        tools=[analyze_video],
+        system_message=VIDEO_EXPERT_PROMPT,
+    )
+    audio_expert = AssistantAgent(
+        name='audio_expert',
+        model_client=base_model_client,
+        tools=[analyze_audio],
+        system_message=AUDIO_EXPERT_PROMPT,
+    )
+    text_expert = AssistantAgent(
+        name='text_expert',
+        model_client=text_model_client,
+        tools=[analyze_text],
+        system_message=TEXT_EXPERT_PROMPT,
+    )
+    judge = AssistantAgent(
+        name='judge',
+        model_client=base_model_client,
+        system_message=JUDGE_PROMPT,
+    )
+
+    # ------------------------------------------------------------------
+    # Create team
+    # ------------------------------------------------------------------
+
+    termination = TextMentionTermination('FINAL ANSWER') | MaxMessageTermination(
+        rounds * 4 + 4  # 4 agents/round + buffer for tool messages
+    )
+
+    team = RoundRobinGroupChat(
+        [video_expert, audio_expert, text_expert, judge],
+        termination_condition=termination,
+    )
+
+    # ------------------------------------------------------------------
+    # Run debate
+    # ------------------------------------------------------------------
+
+    task = (
+        f'Determine if the following utterance is sarcastic or not.\n\n'
+        f'Dialogue:\n{target_sentence}\n\n'
+        f'The last line is the target utterance. '
+        f'Each expert should use their analysis tool to examine evidence, '
+        f'then provide their assessment.'
+    )
+
+    result = await team.run(task=task, cancellation_token=CancellationToken())
+
+    # ------------------------------------------------------------------
+    # Extract results
+    # ------------------------------------------------------------------
+
+    # Count agent turns (non-user messages that have text content)
+    agent_turns = 0
+    for msg in result.messages:
+        source = getattr(msg, 'source', '')
+        if source and source != 'user':
+            content = getattr(msg, 'content', '')
+            if isinstance(content, str) and content.strip():
+                agent_turns += 1
+
+    # Build debate transcript
+    debate_lines = []
+    for msg in result.messages:
+        source = getattr(msg, 'source', 'system')
+        content = getattr(msg, 'content', '')
+        if isinstance(content, str) and content.strip():
+            debate_lines.append(f'[{source}]: {content}')
+    debate_transcript = '\n\n'.join(debate_lines)
+
+    # Extract final answer
+    final_answer = extract_final_answer(result.messages)
+
+    end_time = time.time()
+    latency = end_time - start_time
+
+    # Estimate total API calls:
+    # - tool_api_calls: litellm multimodal calls (exact)
+    # - agent_turns with tool use: 2 model client calls each (tool decision + response)
+    # - agent_turns without tool use: 1 model client call each
+    # Approximate: tool-using turns = tool_api_calls, non-tool turns = agent_turns - tool_api_calls
+    autogen_model_calls = agent_turns + tool_api_calls  # extra call per tool use
+    total_api_calls = tool_api_calls + autogen_model_calls
+
+    print(
+        f'  {test_file}: {final_answer} (label={label}) | '
+        f'api_calls={total_api_calls} '
+        f'(tool={tool_api_calls}, autogen={autogen_model_calls}) | '
+        f'{latency:.1f}s'
+    )
+
+    return {
+        test_file: {
+            'answer': [debate_transcript],
+            'parsed_answer': [final_answer],
+            'label': label,
+            'method': f'autogen_tool_debate_{rounds}r'
+            + (f'_text={effective_text_model}' if text_model else ''),
+            'api_calls': total_api_calls,
+            'tool_api_calls': tool_api_calls,
+            'autogen_model_calls': autogen_model_calls,
+            'agent_turns': agent_turns,
+            'latency': latency,
+            'usage': {
+                'tool_prompt_tokens': tool_prompt_tokens,
+                'tool_completion_tokens': tool_completion_tokens,
+            },
+        }
+    }
+
+
+def run_instance_sync(
+    test_file: str,
+    dataset: dict,
+    dataset_name: str,
+    model: str,
+    rounds: int,
+    text_model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Synchronous wrapper — each thread gets its own event loop."""
+    return asyncio.run(
+        run_instance_async(
+            test_file, dataset, dataset_name, model, rounds, text_model
+        )
+    )
+
+
+# ============================================================================
+# Thread-safe JSONL writer
+# ============================================================================
+
+
+def save_result_threadsafe(result: dict, output_file: str):
+    """Thread-safe append to JSONL file."""
+    with _file_lock:
+        save_result_to_jsonl(result, output_file)
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='AutoGen Multi-Agent Sarcasm Detection (Tool-based)'
+    )
+    parser.add_argument(
+        '--dataset_name',
+        type=str,
+        default='mustard',
+        choices=['urfunny', 'mustard'],
+        help='Dataset name (default: mustard)',
+    )
+    parser.add_argument(
+        '--model',
+        type=str,
+        default=DEFAULT_MODEL,
+        help=f'Model name (default: {DEFAULT_MODEL})',
+    )
+    parser.add_argument(
+        '--dataset',
+        type=str,
+        default=None,
+        help='Path to dataset JSON file',
+    )
+    parser.add_argument(
+        '--output',
+        type=str,
+        default=None,
+        help='Output JSONL file path',
+    )
+    parser.add_argument(
+        '--rounds',
+        type=int,
+        default=DEFAULT_ROUNDS,
+        help=f'Debate rounds (default: {DEFAULT_ROUNDS})',
+    )
+    parser.add_argument(
+        '--max_workers',
+        type=int,
+        default=4,
+        help='Max parallel workers (default: 4)',
+    )
+    parser.add_argument(
+        '--text_model',
+        type=str,
+        default=None,
+        help='Override model for text expert (e.g. o3). Others use --model.',
+    )
+    parser.add_argument(
+        '--instance_id',
+        type=str,
+        default=None,
+        help='Run single instance (debug mode)',
+    )
+    args = parser.parse_args()
+
+    # Reload prompts for the target dataset
+    import sys as _sys
+    _this = _sys.modules[__name__]
+    (_this.VIDEO_EXPERT_PROMPT, _this.AUDIO_EXPERT_PROMPT, _this.TEXT_EXPERT_PROMPT,
+     _this.JUDGE_PROMPT, _this.VIDEO_TOOL_QUERY, _this.AUDIO_TOOL_QUERY, _this.TEXT_TOOL_QUERY) = _load_autogen_prompts(args.dataset_name)
+
+    config = get_dataset_config(args.dataset_name)
+    dataset_path = args.dataset or config.get_default_dataset_path()
+    tag = f'{args.rounds}r'
+    if args.text_model:
+        tag += f'_text-{args.text_model}'
+    output_file = (
+        args.output
+        or f'autogen_{args.dataset_name}_{tag}.jsonl'
+    )
+
+    check_api_key('gemini')
+    if args.text_model and _is_openai_model(args.text_model):
+        if not os.getenv('OPENAI_API_KEY'):
+            raise ValueError('OPENAI_API_KEY not set (needed for --text_model)')
+    litellm.set_verbose = False
+
+    dataset = load_data(dataset_path)
+    model_desc = args.model
+    if args.text_model:
+        model_desc += f' (text: {args.text_model})'
+    print(
+        f'Dataset: {args.dataset_name} ({len(dataset)} samples) | '
+        f'Model: {model_desc} | Rounds: {args.rounds}'
+    )
+
+    # Single instance debug mode
+    if args.instance_id:
+        if args.instance_id not in dataset:
+            print(f'Instance {args.instance_id} not found in dataset')
+            sys.exit(1)
+        print(f'\n--- Debug: {args.instance_id} ---')
+        result = run_instance_sync(
+            args.instance_id, dataset, args.dataset_name,
+            args.model, args.rounds, args.text_model,
+        )
+        data = result[args.instance_id]
+        print(f'\nAnswer: {data["parsed_answer"][0]}')
+        print(f'Label:  {data["label"]}')
+        print(f'API Calls: {data["api_calls"]} (tool={data["tool_api_calls"]}, autogen={data["autogen_model_calls"]})')
+        print(f'Latency: {data["latency"]:.1f}s')
+        print(f'\n--- Debate Transcript ---\n{data["answer"][0][:2000]}')
+        return
+
+    # Full run
+    test_list = list(dataset.keys())
+    processed_keys = load_processed_keys(output_file)
+    remaining = [k for k in test_list if k not in processed_keys]
+
+    if processed_keys:
+        print(
+            f'Resuming: {len(processed_keys)} done, {len(remaining)} remaining'
+        )
+
+    if not remaining:
+        print('All samples already processed.')
+        return
+
+    stats = StatsTracker(
+        cost_input_per_1m=COST_INPUT_PER_1M,
+        cost_output_per_1m=COST_OUTPUT_PER_1M,
+    )
+
+    start_total = time.time()
+    completed = 0
+    errors = 0
+
+    try:
+        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            futures = {}
+            for test_file in remaining:
+                future = executor.submit(
+                    run_instance_sync,
+                    test_file,
+                    dataset,
+                    args.dataset_name,
+                    args.model,
+                    args.rounds,
+                    args.text_model,
+                )
+                futures[future] = test_file
+
+            for future in as_completed(futures):
+                test_file = futures[future]
+                try:
+                    result = future.result()
+                    save_result_threadsafe(result, output_file)
+                    data = result[test_file]
+                    stats.add(
+                        data['latency'],
+                        data['usage']['tool_prompt_tokens'],
+                        data['usage']['tool_completion_tokens'],
+                        data['api_calls'],
+                    )
+                    completed += 1
+                except Exception as e:
+                    errors += 1
+                    print(f'[ERROR] {test_file}: {e}')
+    finally:
+        elapsed = time.time() - start_total
+        print(f'\n{"=" * 60}')
+        print(f'Completed: {completed} | Errors: {errors} | Total time: {elapsed:.1f}s')
+        stats.print_summary(f'AutoGen Tool-Debate ({args.rounds} rounds)')
+        print(f'Output: {output_file}')
+        print(f'Evaluate: python calc_ctm_res.py {output_file} -d {args.dataset_name}')
+
+
+if __name__ == '__main__':
+    main()

--- a/exp_affective/run_metagpt.py
+++ b/exp_affective/run_metagpt.py
@@ -1,0 +1,682 @@
+"""
+MetaGPT-style multi-agent baseline for sarcasm detection on MUStARD.
+
+4-stage SOP pipeline:
+  Stage 1: Independent modality analysis (3 agents in parallel)
+  Stage 2: Cross-modal synthesis (1 agent)
+  Stage 3: Critical review (1 agent)
+  Stage 4: Final judgment (1 agent)
+
+Total LLM calls per sample: 6 (3 parallel + 3 sequential)
+Backbone: gemini/gemini-2.5-flash-lite via litellm
+
+Examples:
+    python run_metagpt.py --dataset_name mustard --max_workers 8
+    python run_metagpt.py --dataset_name mustard --max_workers 4 --resume
+    python run_metagpt.py --dataset_name mustard --max_workers 1 --sleep 2
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import litellm
+from dataset_configs import get_dataset_config
+from llm_utils import (
+    get_audio_path,
+    get_muted_video_path,
+    load_data,
+)
+
+file_lock = Lock()
+
+MODEL = 'gemini/gemini-2.5-flash-lite'
+
+# =============================================================================
+# MetaGPT Agent Prompts (Role-based, structured communication)
+# =============================================================================
+
+# Stage 1 prompts: use the SAME system prompts as CTM processors (exp22) for fair comparison.
+# Only the architecture (SOP pipeline vs competition/fusion) should differ.
+def _load_ctm_prompts(dataset_name='mustard'):
+    """Load system prompts from CTM config to stay aligned."""
+    config_map = {
+        'mustard': 'sarcasm_ctm_config.json',
+        'urfunny': 'urfunny_test_qwen_v12_config.json',
+    }
+    config_path = os.path.join(
+        os.path.dirname(__file__), '..', 'ctm_conf', config_map.get(dataset_name, config_map['mustard']),
+    )
+    with open(config_path) as f:
+        cfg = json.load(f)
+    return cfg['processors_config']
+
+
+def _get_metagpt_prompts(dataset_name='mustard'):
+    if dataset_name == 'urfunny':
+        task = 'humor detection'
+        yes_label = 'humorous'
+        no_label = 'not humorous'
+        pitfalls = (
+            '   - Enthusiasm/excitement with humor\n'
+            '   - Deadpan delivery with comedic intent\n'
+            '   - Informative surprises with actual jokes\n'
+            '   - Rhetorical contrasts with humorous incongruity'
+        )
+    else:
+        task = 'sarcasm detection'
+        yes_label = 'sarcastic'
+        no_label = 'not sarcastic'
+        pitfalls = (
+            '   - Genuine anger/frustration with sarcasm\n'
+            '   - Dry/deadpan delivery with sarcastic intent\n'
+            '   - Playful teasing with sarcasm\n'
+            '   - Short responses as automatically non-sarcastic'
+        )
+
+    synthesizer = (
+        f'You are the Synthesizer in a multi-agent {task} team. '
+        'You have received independent analysis reports from three modality experts '
+        '(Text, Audio, Video). Your role is to integrate their findings into a '
+        'coherent cross-modal synthesis.\n\n'
+        'Your synthesis MUST cover:\n'
+        '1. **Agreement Points**: Where do the modality experts agree? What evidence is consistent?\n'
+        '2. **Conflicts**: Where do experts disagree? Which modality provides stronger evidence?\n'
+        f'3. **Evidence Strength**: Rate the overall evidence for {yes_label} vs {no_label}.\n'
+        '4. **Modality Reliability**: For this specific sample, which modality seems most reliable and why?\n'
+        f'5. **Synthesis Verdict**: Based on integrated evidence, is the person likely {yes_label} or not?\n\n'
+        'Weigh the evidence carefully. Text analysis typically provides the strongest semantic signal, '
+        'audio provides tonal confirmation/contradiction, and video provides supplementary visual cues.'
+    )
+    critic = (
+        f'You are the Critic in a multi-agent {task} team. '
+        'You have received the original modality analyses AND the synthesizer\'s integration. '
+        'Your role is to critically review the synthesis and challenge weak reasoning.\n\n'
+        'Your review MUST cover:\n'
+        '1. **Logical Consistency**: Is the synthesis logically sound? Are conclusions supported by evidence?\n'
+        '2. **Overlooked Evidence**: Did the synthesizer miss or underweight important evidence from any modality?\n'
+        '3. **Common Pitfalls**: Flag if the analysis might be confusing:\n'
+        f'{pitfalls}\n'
+        '4. **Uncertainty Assessment**: How uncertain is the overall judgment? Are there genuine ambiguities?\n'
+        '5. **Revised Verdict**: After your critical review, do you agree with the synthesis or disagree? Why?\n\n'
+        'Be rigorous. Your job is to catch errors before the final decision is made.'
+    )
+    judge = (
+        f'You are the Final Judge in a multi-agent {task} team. '
+        'You have received all prior analyses: three modality reports, a cross-modal synthesis, '
+        f'and a critical review. Your role is to make the final {task} determination.\n\n'
+        'Review all evidence carefully and make your decision.\n\n'
+        f'Your answer MUST start with either "Yes" ({yes_label}) or "No" ({no_label}), '
+        'followed by a brief explanation citing the most decisive evidence.\n\n'
+        'Guidelines:\n'
+        f'- If the Critic identified significant weaknesses in the {yes_label} case, weigh that heavily.\n'
+        '- If modalities strongly agree, trust the consensus.\n'
+        '- If modalities conflict, prioritize text > audio > video for semantic judgment.\n'
+        '- Make a definitive decision — do not hedge.'
+    )
+    return synthesizer, critic, judge
+
+
+_CTM_PROMPTS = _load_ctm_prompts()
+TEXT_ANALYST_SYSTEM = _CTM_PROMPTS['language_processor']['system_prompt']
+AUDIO_ANALYST_SYSTEM = _CTM_PROMPTS['audio_processor']['system_prompt']
+VIDEO_ANALYST_SYSTEM = _CTM_PROMPTS['video_processor']['system_prompt']
+SYNTHESIZER_SYSTEM, CRITIC_SYSTEM, JUDGE_SYSTEM = _get_metagpt_prompts()
+
+
+# =============================================================================
+# LLM Call with Retry (returns text + usage stats)
+# =============================================================================
+
+def _call_llm(messages, max_retries=3):
+    """Call gemini-2.5-flash-lite with retry.
+
+    Returns:
+        tuple: (text, usage_dict) where usage_dict has
+               prompt_tokens, completion_tokens, total_tokens, api_calls, latency
+    """
+    start = time.time()
+    api_calls = 0
+    for attempt in range(1, max_retries + 1):
+        try:
+            api_calls += 1
+            response = litellm.completion(
+                model=MODEL,
+                messages=messages,
+                temperature=0.0,
+            )
+            text = response.choices[0].message.content
+            usage = {
+                'prompt_tokens': getattr(response.usage, 'prompt_tokens', 0) or 0,
+                'completion_tokens': getattr(response.usage, 'completion_tokens', 0) or 0,
+                'total_tokens': getattr(response.usage, 'total_tokens', 0) or 0,
+                'api_calls': api_calls,
+                'latency': time.time() - start,
+            }
+            if text:
+                return text.strip(), usage
+        except Exception as e:
+            print(f'  LLM attempt {attempt}/{max_retries} failed: {e}')
+            if attempt < max_retries:
+                time.sleep(2 ** attempt)
+    return None, {
+        'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0,
+        'api_calls': api_calls, 'latency': time.time() - start,
+    }
+
+
+# =============================================================================
+# Stage 1: Independent Modality Analysis (parallel)
+# =============================================================================
+
+def stage1_text_analysis(query, target_sentence):
+    """Text Analyst: analyze dialogue transcript."""
+    messages = [
+        {'role': 'system', 'content': TEXT_ANALYST_SYSTEM},
+        {'role': 'user', 'content': (
+            f'{query}\n\n'
+            f'Dialogue transcript:\n{target_sentence}'
+        )},
+    ]
+    text, usage = _call_llm(messages)
+    return text, usage
+
+
+def stage1_audio_analysis(query, audio_path):
+    """Audio Analyst: analyze audio recording."""
+    if not audio_path or not os.path.exists(audio_path):
+        empty_usage = {
+            'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0,
+            'api_calls': 0, 'latency': 0.0,
+        }
+        return '[Audio unavailable — no audio file found for this sample.]', empty_usage
+
+    ext = audio_path.split('.')[-1].lower()
+    mime_map = {
+        'mp3': 'audio/mp3', 'wav': 'audio/wav',
+        'mp4': 'audio/mp4', 'aac': 'audio/aac',
+    }
+    mime_type = mime_map.get(ext, 'audio/mp4')
+    with open(audio_path, 'rb') as f:
+        encoded = base64.b64encode(f.read()).decode('utf-8')
+
+    messages = [
+        {'role': 'system', 'content': AUDIO_ANALYST_SYSTEM},
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': (
+                f'{query}\n\nAnalyze the audio recording and produce your structured report.'
+            )},
+            {'type': 'image_url', 'image_url': {
+                'url': f'data:{mime_type};base64,{encoded}',
+            }},
+        ]},
+    ]
+    text, usage = _call_llm(messages)
+    return text, usage
+
+
+def stage1_video_analysis(query, video_path):
+    """Video Analyst: analyze muted video."""
+    if not video_path or not os.path.exists(video_path):
+        empty_usage = {
+            'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0,
+            'api_calls': 0, 'latency': 0.0,
+        }
+        return '[Video unavailable — no video file found for this sample.]', empty_usage
+
+    with open(video_path, 'rb') as f:
+        encoded = base64.b64encode(f.read()).decode('utf-8')
+
+    messages = [
+        {'role': 'system', 'content': VIDEO_ANALYST_SYSTEM},
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': (
+                f'{query}\n\nAnalyze the muted video and produce your structured report.'
+            )},
+            {'type': 'image_url', 'image_url': {
+                'url': f'data:video/mp4;base64,{encoded}',
+            }},
+        ]},
+    ]
+    text, usage = _call_llm(messages)
+    return text, usage
+
+
+# =============================================================================
+# Stage 2: Cross-Modal Synthesis
+# =============================================================================
+
+def stage2_synthesis(query, text_report, audio_report, video_report):
+    """Synthesizer: integrate all modality reports."""
+    messages = [
+        {'role': 'system', 'content': SYNTHESIZER_SYSTEM},
+        {'role': 'user', 'content': (
+            f'Task: {query}\n\n'
+            f'=== TEXT ANALYST REPORT ===\n{text_report}\n\n'
+            f'=== AUDIO ANALYST REPORT ===\n{audio_report}\n\n'
+            f'=== VIDEO ANALYST REPORT ===\n{video_report}\n\n'
+            'Produce your cross-modal synthesis.'
+        )},
+    ]
+    text, usage = _call_llm(messages)
+    return text, usage
+
+
+# =============================================================================
+# Stage 3: Critical Review
+# =============================================================================
+
+def stage3_critic(query, text_report, audio_report, video_report, synthesis):
+    """Critic: review and challenge the synthesis."""
+    messages = [
+        {'role': 'system', 'content': CRITIC_SYSTEM},
+        {'role': 'user', 'content': (
+            f'Task: {query}\n\n'
+            f'=== TEXT ANALYST REPORT ===\n{text_report}\n\n'
+            f'=== AUDIO ANALYST REPORT ===\n{audio_report}\n\n'
+            f'=== VIDEO ANALYST REPORT ===\n{video_report}\n\n'
+            f'=== SYNTHESIZER REPORT ===\n{synthesis}\n\n'
+            'Critically review the synthesis. Identify weaknesses, overlooked evidence, '
+            'and potential errors.'
+        )},
+    ]
+    text, usage = _call_llm(messages)
+    return text, usage
+
+
+# =============================================================================
+# Stage 4: Final Judgment
+# =============================================================================
+
+def stage4_judge(query, text_report, audio_report, video_report, synthesis, critique):
+    """Judge: make final Yes/No decision."""
+    messages = [
+        {'role': 'system', 'content': JUDGE_SYSTEM},
+        {'role': 'user', 'content': (
+            f'Task: {query}\n\n'
+            f'=== TEXT ANALYST REPORT ===\n{text_report}\n\n'
+            f'=== AUDIO ANALYST REPORT ===\n{audio_report}\n\n'
+            f'=== VIDEO ANALYST REPORT ===\n{video_report}\n\n'
+            f'=== SYNTHESIZER REPORT ===\n{synthesis}\n\n'
+            f'=== CRITIC REVIEW ===\n{critique}\n\n'
+            'Make your final determination. Start with "Yes" or "No".'
+        )},
+    ]
+    text, usage = _call_llm(messages)
+    return text, usage
+
+
+# =============================================================================
+# Full MetaGPT Pipeline
+# =============================================================================
+
+def _merge_usage(all_usages):
+    """Aggregate usage stats from all stages."""
+    total = {
+        'total_api_calls': 0,
+        'total_prompt_tokens': 0,
+        'total_completion_tokens': 0,
+        'total_tokens': 0,
+        'stage_latencies': {},
+    }
+    for stage_name, usage in all_usages:
+        total['total_api_calls'] += usage.get('api_calls', 0)
+        total['total_prompt_tokens'] += usage.get('prompt_tokens', 0)
+        total['total_completion_tokens'] += usage.get('completion_tokens', 0)
+        total['total_tokens'] += usage.get('total_tokens', 0)
+        total['stage_latencies'][stage_name] = usage.get('latency', 0.0)
+    return total
+
+
+def run_metagpt_pipeline(query, target_sentence, audio_path, video_path):
+    """Run the full 4-stage MetaGPT SOP pipeline for one sample.
+
+    Returns:
+        tuple: (final_answer, stage_outputs_dict, usage_stats_dict)
+    """
+    all_usages = []
+
+    # Stage 1: Independent analysis (parallel via threads)
+    stage1_results = {}
+    stage1_usages = {}
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            executor.submit(stage1_text_analysis, query, target_sentence): 'text',
+            executor.submit(stage1_audio_analysis, query, audio_path): 'audio',
+            executor.submit(stage1_video_analysis, query, video_path): 'video',
+        }
+        for future in as_completed(futures):
+            modality = futures[future]
+            text, usage = future.result()
+            stage1_results[modality] = text or f'[{modality} analysis failed]'
+            stage1_usages[modality] = usage
+            all_usages.append((f'stage1_{modality}', usage))
+
+    text_report = stage1_results['text']
+    audio_report = stage1_results['audio']
+    video_report = stage1_results['video']
+
+    # Stage 2: Cross-modal synthesis
+    synthesis, s2_usage = stage2_synthesis(query, text_report, audio_report, video_report)
+    all_usages.append(('stage2_synthesis', s2_usage))
+    if not synthesis:
+        synthesis = '[Synthesis failed]'
+
+    # Stage 3: Critical review
+    critique, s3_usage = stage3_critic(
+        query, text_report, audio_report, video_report, synthesis,
+    )
+    all_usages.append(('stage3_critic', s3_usage))
+    if not critique:
+        critique = '[Critique failed]'
+
+    # Stage 4: Final judgment
+    final_answer, s4_usage = stage4_judge(
+        query, text_report, audio_report, video_report, synthesis, critique,
+    )
+    all_usages.append(('stage4_judge', s4_usage))
+
+    stage_outputs = {
+        'text_report': text_report,
+        'audio_report': audio_report,
+        'video_report': video_report,
+        'synthesis': synthesis,
+        'critique': critique,
+    }
+
+    usage_stats = _merge_usage(all_usages)
+
+    return final_answer, stage_outputs, usage_stats
+
+
+# =============================================================================
+# Instance Runner
+# =============================================================================
+
+def run_instance(test_file, dataset, dataset_name, output_file):
+    """Process a single sample through the MetaGPT pipeline."""
+    try:
+        config = get_dataset_config(dataset_name)
+        sample = dataset[test_file]
+        target_sentence = config.get_text_field(sample)
+        label = config.get_label_field(sample)
+        query = config.get_task_query()
+
+        audio_path = get_audio_path(test_file, dataset_name)
+        video_path = get_muted_video_path(test_file, dataset_name)
+
+        if not os.path.exists(audio_path):
+            audio_path = None
+        if not os.path.exists(video_path):
+            video_path = None
+
+        start_time = time.time()
+
+        final_answer, stage_outputs, usage_stats = run_metagpt_pipeline(
+            query, target_sentence, audio_path, video_path,
+        )
+
+        elapsed = time.time() - start_time
+
+        parsed = final_answer.strip() if final_answer else ''
+
+        print(
+            f'[{test_file}] {elapsed:.1f}s | '
+            f'api_calls={usage_stats["total_api_calls"]} '
+            f'tokens={usage_stats["total_tokens"]} | '
+            f'{parsed[:60]}'
+        )
+
+        result = {
+            test_file: {
+                'answer': [final_answer or ''],
+                'parsed_answer': [parsed],
+                'label': label,
+                'method': 'metagpt',
+                'latency': elapsed,
+                'api_calls': usage_stats['total_api_calls'],
+                'prompt_tokens': usage_stats['total_prompt_tokens'],
+                'completion_tokens': usage_stats['total_completion_tokens'],
+                'total_tokens': usage_stats['total_tokens'],
+                'stage_latencies': usage_stats['stage_latencies'],
+                'stage_outputs': stage_outputs,
+            }
+        }
+
+        with file_lock:
+            with open(output_file, 'a', encoding='utf-8') as f:
+                f.write(json.dumps(result, ensure_ascii=False) + '\n')
+
+        return f'OK {test_file}'
+
+    except Exception as e:
+        print(f'[{test_file}] ERROR: {e}')
+        import traceback
+        traceback.print_exc()
+        return f'FAIL {test_file}: {e}'
+
+
+# =============================================================================
+# Parallel Runner
+# =============================================================================
+
+def load_processed_keys(output_file):
+    """Load already processed keys from JSONL output file for resume."""
+    processed = set()
+    try:
+        with open(output_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.strip():
+                    result = json.loads(line)
+                    processed.update(result.keys())
+    except FileNotFoundError:
+        pass
+    return processed
+
+
+def run_parallel(
+    dataset, dataset_name, max_workers=4,
+    output_file='metagpt_mustard.jsonl', resume=False, sleep_between=0,
+):
+    test_list = list(dataset.keys())
+    print(f'Total test samples: {len(test_list)}')
+    print(f'Using {max_workers} workers')
+    print(f'Output file: {output_file}')
+
+    if resume:
+        processed = load_processed_keys(output_file)
+        test_list = [k for k in test_list if k not in processed]
+        print(f'Resume mode: {len(processed)} already done, {len(test_list)} remaining')
+    else:
+        with open(output_file, 'w', encoding='utf-8'):
+            pass
+
+    if not test_list:
+        print('Nothing to do.')
+        return
+
+    print('=' * 60)
+    print(f'MetaGPT 4-stage SOP pipeline | Model: {MODEL}')
+    print(f'Samples: {len(test_list)} | Workers: {max_workers}')
+    print('=' * 60)
+
+    start_time = time.time()
+    completed_count = 0
+
+    if max_workers == 1 and sleep_between > 0:
+        for test_file in test_list:
+            try:
+                result = run_instance(
+                    test_file, dataset, dataset_name, output_file,
+                )
+                completed_count += 1
+                print(f'Progress: {completed_count}/{len(test_list)} - {result}')
+            except Exception as exc:
+                completed_count += 1
+                print(f'Error processing {test_file}: {exc}')
+            if sleep_between > 0 and completed_count < len(test_list):
+                time.sleep(sleep_between)
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_test = {
+                executor.submit(
+                    run_instance, test_file, dataset, dataset_name, output_file,
+                ): test_file
+                for test_file in test_list
+            }
+
+            for future in as_completed(future_to_test):
+                test_file = future_to_test[future]
+                completed_count += 1
+                try:
+                    result = future.result()
+                    print(f'Progress: {completed_count}/{len(test_list)} - {result}')
+                except Exception as exc:
+                    print(f'Error processing {test_file}: {exc}')
+
+    total_time = time.time() - start_time
+
+    # Print aggregate stats from the output file
+    _print_aggregate_stats(output_file, total_time)
+
+
+def _print_aggregate_stats(output_file, wall_time):
+    """Read the JSONL output and print aggregate API call / latency / token stats."""
+    total_api_calls = 0
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    total_tokens = 0
+    latencies = []
+    stage_latency_sums = {}
+    sample_count = 0
+
+    try:
+        with open(output_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                for _key, val in record.items():
+                    sample_count += 1
+                    total_api_calls += val.get('api_calls', 0)
+                    total_prompt_tokens += val.get('prompt_tokens', 0)
+                    total_completion_tokens += val.get('completion_tokens', 0)
+                    total_tokens += val.get('total_tokens', 0)
+                    latencies.append(val.get('latency', 0.0))
+                    for stage, lat in val.get('stage_latencies', {}).items():
+                        stage_latency_sums.setdefault(stage, []).append(lat)
+    except Exception as e:
+        print(f'Warning: could not read stats from {output_file}: {e}')
+        return
+
+    if sample_count == 0:
+        print('No results to summarize.')
+        return
+
+    avg_latency = sum(latencies) / sample_count
+    avg_api_calls = total_api_calls / sample_count
+
+    # Gemini 2.5 Flash Lite pricing (per 1M tokens)
+    cost_input_per_1m = 0.075
+    cost_output_per_1m = 0.30
+    total_cost = (
+        total_prompt_tokens / 1_000_000 * cost_input_per_1m
+        + total_completion_tokens / 1_000_000 * cost_output_per_1m
+    )
+
+    print('\n' + '=' * 60)
+    print('METAGPT PERFORMANCE & COST SUMMARY')
+    print('=' * 60)
+    print(f'Total Samples:            {sample_count}')
+    print(f'Wall-clock Time:          {wall_time:.1f}s')
+    print('-' * 40)
+    print(f'Total API Calls:          {total_api_calls}')
+    print(f'Avg API Calls/Sample:     {avg_api_calls:.1f}')
+    print(f'Avg Latency/Sample:       {avg_latency:.2f}s')
+    print('-' * 40)
+    print(f'Total Prompt Tokens:      {total_prompt_tokens:,}')
+    print(f'Total Completion Tokens:  {total_completion_tokens:,}')
+    print(f'Total Tokens:             {total_tokens:,}')
+    print(f'Avg Tokens/Sample:        {total_tokens / sample_count:,.0f}')
+    print('-' * 40)
+    print(f'Estimated Cost:           ${total_cost:.4f}')
+    print(f'Avg Cost/Sample:          ${total_cost / sample_count:.6f}')
+
+    if stage_latency_sums:
+        print('-' * 40)
+        print('Avg Latency by Stage:')
+        for stage in sorted(stage_latency_sums.keys()):
+            vals = stage_latency_sums[stage]
+            print(f'  {stage:25s} {sum(vals) / len(vals):.2f}s')
+
+    print('=' * 60 + '\n')
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='MetaGPT-style multi-agent baseline for sarcasm detection',
+    )
+    parser.add_argument(
+        '--dataset_name', type=str, default='mustard',
+        choices=['urfunny', 'mustard'],
+        help='Dataset name (default: mustard)',
+    )
+    parser.add_argument(
+        '--dataset', type=str, default=None,
+        help='Path to dataset JSON file (default: auto)',
+    )
+    parser.add_argument(
+        '--output', type=str, default=None,
+        help='Output JSONL file path',
+    )
+    parser.add_argument(
+        '--max_workers', type=int, default=8,
+        help='Number of parallel workers for samples (default: 8)',
+    )
+    parser.add_argument(
+        '--resume', action='store_true',
+        help='Resume from existing output file',
+    )
+    parser.add_argument(
+        '--sleep', type=float, default=0,
+        help='Sleep seconds between samples (for rate limiting)',
+    )
+    args = parser.parse_args()
+
+    config = get_dataset_config(args.dataset_name)
+    if args.dataset is None:
+        args.dataset = config.get_default_dataset_path()
+
+    # Reload prompts for the target dataset
+    import sys as _sys
+    _this = _sys.modules[__name__]
+    _prompts = _load_ctm_prompts(args.dataset_name)
+    _this.TEXT_ANALYST_SYSTEM = _prompts['language_processor']['system_prompt']
+    _this.AUDIO_ANALYST_SYSTEM = _prompts['audio_processor']['system_prompt']
+    _this.VIDEO_ANALYST_SYSTEM = _prompts['video_processor']['system_prompt']
+    _this.SYNTHESIZER_SYSTEM, _this.CRITIC_SYSTEM, _this.JUDGE_SYSTEM = _get_metagpt_prompts(args.dataset_name)
+
+    output_file = args.output or f'metagpt_{args.dataset_name}.jsonl'
+
+    dataset = load_data(args.dataset)
+    print(f'Dataset: {args.dataset_name} | Model: {MODEL} | Samples: {len(dataset)}')
+
+    run_parallel(
+        dataset,
+        args.dataset_name,
+        max_workers=args.max_workers,
+        output_file=output_file,
+        resume=args.resume,
+        sleep_between=args.sleep,
+    )

--- a/exp_affective/run_moa.py
+++ b/exp_affective/run_moa.py
@@ -1,0 +1,480 @@
+"""
+MoA (Mixture of Agents) baseline for affective detection (MUStARD / URFunny).
+
+1-layer MoA: 3 modality proposers (parallel) + 1 aggregator
+Total LLM calls per sample: 4 (3 parallel + 1 sequential)
+Backbone: gemini/gemini-2.5-flash-lite via litellm
+
+Proposer system prompts are loaded from the dataset-specific CTM config:
+  - mustard  -> sarcasm_ctm_config.json
+  - urfunny  -> urfunny_test_qwen_v12_config.json
+
+Examples:
+    python run_moa.py --dataset_name mustard --max_workers 8
+    python run_moa.py --dataset_name urfunny --max_workers 8
+    python run_moa.py --dataset_name mustard --max_workers 4 --resume
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import litellm
+from dataset_configs import get_dataset_config
+from llm_utils import (
+    get_audio_path,
+    get_muted_video_path,
+    load_data,
+)
+
+file_lock = Lock()
+
+MODEL = 'gemini/gemini-2.5-flash-lite'
+
+# =============================================================================
+# Load CTM-aligned proposer prompts (same as MetaGPT v2)
+# =============================================================================
+
+def _load_ctm_prompts(dataset_name='mustard'):
+    config_map = {
+        'mustard': 'sarcasm_ctm_config.json',
+        'urfunny': 'urfunny_test_qwen_v12_config.json',
+    }
+    config_path = os.path.join(
+        os.path.dirname(__file__), '..', 'ctm_conf', config_map.get(dataset_name, config_map['mustard']),
+    )
+    with open(config_path) as f:
+        cfg = json.load(f)
+    return cfg['processors_config']
+
+
+def _get_aggregator_prompt(dataset_name='mustard'):
+    if dataset_name == 'urfunny':
+        return (
+            'You are a humor detection aggregator. You have been provided with independent analyses '
+            'from three modality-specific experts (text, audio, video) about whether a punchline is '
+            'humorous. Your task is to critically evaluate their analyses and make a final determination.\n\n'
+            'Key guidelines:\n'
+            '- Weigh evidence from all modalities. Text analysis typically provides the strongest '
+            'semantic signal, audio provides tonal/laughter confirmation, video provides supplementary cues.\n'
+            '- If experts disagree, consider which modality has stronger evidence for this specific case.\n'
+            '- If an expert expresses low confidence or uncertainty, weigh their analysis less.\n'
+            '- Do not simply follow the majority — evaluate the quality of each expert\'s reasoning.\n\n'
+            'Your answer MUST start with either "Yes" (humorous) or "No" (not humorous), '
+            'followed by a brief explanation citing the most decisive evidence.\n\n'
+            'Expert analyses:'
+        )
+    return (
+        'You are a sarcasm detection aggregator. You have been provided with independent analyses '
+        'from three modality-specific experts (text, audio, video) about whether a person is being '
+        'sarcastic. Your task is to critically evaluate their analyses and make a final determination.\n\n'
+        'Key guidelines:\n'
+        '- Weigh evidence from all modalities. Text analysis typically provides the strongest '
+        'semantic signal, audio provides tonal confirmation, video provides supplementary cues.\n'
+        '- If experts disagree, consider which modality has stronger evidence for this specific case.\n'
+        '- If an expert expresses low confidence or uncertainty, weigh their analysis less.\n'
+        '- Do not simply follow the majority — evaluate the quality of each expert\'s reasoning.\n\n'
+        'Your answer MUST start with either "Yes" (sarcastic) or "No" (not sarcastic), '
+        'followed by a brief explanation citing the most decisive evidence.\n\n'
+        'Expert analyses:'
+    )
+
+
+# Defaults (overridden in main based on dataset_name)
+_CTM_PROMPTS = _load_ctm_prompts()
+TEXT_PROPOSER_SYSTEM = _CTM_PROMPTS['language_processor']['system_prompt']
+AUDIO_PROPOSER_SYSTEM = _CTM_PROMPTS['audio_processor']['system_prompt']
+VIDEO_PROPOSER_SYSTEM = _CTM_PROMPTS['video_processor']['system_prompt']
+MOA_AGGREGATOR_SYSTEM = _get_aggregator_prompt()
+
+
+# =============================================================================
+# LLM Call with Retry
+# =============================================================================
+
+def _call_llm(messages, max_retries=3):
+    """Call gemini-2.5-flash-lite with retry. Returns (text, usage_dict)."""
+    start = time.time()
+    api_calls = 0
+    for attempt in range(1, max_retries + 1):
+        try:
+            api_calls += 1
+            response = litellm.completion(
+                model=MODEL, messages=messages, temperature=0.0,
+            )
+            text = response.choices[0].message.content
+            usage = {
+                'prompt_tokens': getattr(response.usage, 'prompt_tokens', 0) or 0,
+                'completion_tokens': getattr(response.usage, 'completion_tokens', 0) or 0,
+                'total_tokens': getattr(response.usage, 'total_tokens', 0) or 0,
+                'api_calls': api_calls,
+                'latency': time.time() - start,
+            }
+            if text:
+                return text.strip(), usage
+        except Exception as e:
+            print(f'  LLM attempt {attempt}/{max_retries} failed: {e}')
+            if attempt < max_retries:
+                time.sleep(2 ** attempt)
+    return None, {
+        'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0,
+        'api_calls': api_calls, 'latency': time.time() - start,
+    }
+
+
+# =============================================================================
+# Proposers (modality-specific, parallel)
+# =============================================================================
+
+def proposer_text(query, target_sentence):
+    """Text proposer."""
+    messages = [
+        {'role': 'system', 'content': TEXT_PROPOSER_SYSTEM},
+        {'role': 'user', 'content': (
+            f'{query}\n\nThe relevant text of the query is: {target_sentence}'
+        )},
+    ]
+    return _call_llm(messages)
+
+
+def proposer_audio(query, audio_path):
+    """Audio proposer."""
+    if not audio_path or not os.path.exists(audio_path):
+        empty = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0,
+                 'api_calls': 0, 'latency': 0.0}
+        return '[Audio unavailable]', empty
+
+    ext = audio_path.split('.')[-1].lower()
+    mime_map = {'mp3': 'audio/mp3', 'wav': 'audio/wav', 'mp4': 'audio/mp4', 'aac': 'audio/aac'}
+    mime_type = mime_map.get(ext, 'audio/mp4')
+    with open(audio_path, 'rb') as f:
+        encoded = base64.b64encode(f.read()).decode('utf-8')
+
+    messages = [
+        {'role': 'system', 'content': AUDIO_PROPOSER_SYSTEM},
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': f'{query}\n\nBased on the audio, provide your analysis.'},
+            {'type': 'image_url', 'image_url': {'url': f'data:{mime_type};base64,{encoded}'}},
+        ]},
+    ]
+    return _call_llm(messages)
+
+
+def proposer_video(query, video_path):
+    """Video proposer."""
+    if not video_path or not os.path.exists(video_path):
+        empty = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0,
+                 'api_calls': 0, 'latency': 0.0}
+        return '[Video unavailable]', empty
+
+    with open(video_path, 'rb') as f:
+        encoded = base64.b64encode(f.read()).decode('utf-8')
+
+    messages = [
+        {'role': 'system', 'content': VIDEO_PROPOSER_SYSTEM},
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': f'{query}\n\nAnalyze the muted video.'},
+            {'type': 'image_url', 'image_url': {'url': f'data:video/mp4;base64,{encoded}'}},
+        ]},
+    ]
+    return _call_llm(messages)
+
+
+# =============================================================================
+# Aggregator
+# =============================================================================
+
+def aggregator(query, proposer_outputs):
+    """MoA aggregator: synthesize all proposer outputs into final answer."""
+    # Build system prompt with numbered references (faithful to MoA paper)
+    system = MOA_AGGREGATOR_SYSTEM
+    for i, (modality, output) in enumerate(proposer_outputs):
+        system += f'\n{i+1}. [{modality}] {output}'
+
+    messages = [
+        {'role': 'system', 'content': system},
+        {'role': 'user', 'content': query},
+    ]
+    return _call_llm(messages)
+
+
+# =============================================================================
+# Full MoA Pipeline
+# =============================================================================
+
+def run_moa_pipeline(query, target_sentence, audio_path, video_path):
+    """Run 1-layer MoA: 3 proposers in parallel, then aggregator.
+
+    Returns:
+        tuple: (final_answer, stage_outputs, usage_stats)
+    """
+    all_usages = []
+    round_results = {}
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            executor.submit(proposer_text, query, target_sentence): 'text',
+            executor.submit(proposer_audio, query, audio_path): 'audio',
+            executor.submit(proposer_video, query, video_path): 'video',
+        }
+        for future in as_completed(futures):
+            modality = futures[future]
+            text, usage = future.result()
+            round_results[modality] = text or f'[{modality} failed]'
+            all_usages.append((modality, usage))
+
+    # Final aggregation
+    proposer_outputs = [
+        ('Text Analysis', round_results['text']),
+        ('Audio Analysis', round_results['audio']),
+        ('Video Analysis', round_results['video']),
+    ]
+    final_answer, agg_usage = aggregator(query, proposer_outputs)
+    all_usages.append(('aggregator', agg_usage))
+
+    usage_stats = {
+        'total_api_calls': sum(u.get('api_calls', 0) for _, u in all_usages),
+        'total_prompt_tokens': sum(u.get('prompt_tokens', 0) for _, u in all_usages),
+        'total_completion_tokens': sum(u.get('completion_tokens', 0) for _, u in all_usages),
+        'total_tokens': sum(u.get('total_tokens', 0) for _, u in all_usages),
+        'stage_latencies': {name: u.get('latency', 0.0) for name, u in all_usages},
+    }
+
+    stage_outputs = {
+        'text_proposer': round_results['text'],
+        'audio_proposer': round_results['audio'],
+        'video_proposer': round_results['video'],
+    }
+
+    return final_answer, stage_outputs, usage_stats
+
+
+# =============================================================================
+# Instance Runner
+# =============================================================================
+
+def run_instance(test_file, dataset, dataset_name, output_file):
+    try:
+        config = get_dataset_config(dataset_name)
+        sample = dataset[test_file]
+        target_sentence = config.get_text_field(sample)
+        label = config.get_label_field(sample)
+        query = config.get_task_query()
+
+        audio_path = get_audio_path(test_file, dataset_name)
+        video_path = get_muted_video_path(test_file, dataset_name)
+        if not os.path.exists(audio_path):
+            audio_path = None
+        if not os.path.exists(video_path):
+            video_path = None
+
+        start_time = time.time()
+        final_answer, stage_outputs, usage_stats = run_moa_pipeline(
+            query, target_sentence, audio_path, video_path,
+        )
+        elapsed = time.time() - start_time
+
+        parsed = final_answer.strip() if final_answer else ''
+        print(
+            f'[{test_file}] {elapsed:.1f}s | '
+            f'api={usage_stats["total_api_calls"]} '
+            f'tok={usage_stats["total_tokens"]} | '
+            f'{parsed[:60]}'
+        )
+
+        result = {
+            test_file: {
+                'answer': [final_answer or ''],
+                'parsed_answer': [parsed],
+                'label': label,
+                'method': 'moa_1round',
+                'latency': elapsed,
+                'api_calls': usage_stats['total_api_calls'],
+                'prompt_tokens': usage_stats['total_prompt_tokens'],
+                'completion_tokens': usage_stats['total_completion_tokens'],
+                'total_tokens': usage_stats['total_tokens'],
+                'stage_latencies': usage_stats['stage_latencies'],
+                'stage_outputs': stage_outputs,
+            }
+        }
+
+        with file_lock:
+            with open(output_file, 'a', encoding='utf-8') as f:
+                f.write(json.dumps(result, ensure_ascii=False) + '\n')
+        return f'OK {test_file}'
+
+    except Exception as e:
+        print(f'[{test_file}] ERROR: {e}')
+        import traceback
+        traceback.print_exc()
+        return f'FAIL {test_file}: {e}'
+
+
+# =============================================================================
+# Parallel Runner
+# =============================================================================
+
+def load_processed_keys(output_file):
+    processed = set()
+    try:
+        with open(output_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.strip():
+                    processed.update(json.loads(line).keys())
+    except FileNotFoundError:
+        pass
+    return processed
+
+
+def run_parallel(dataset, dataset_name, max_workers=4,
+                 output_file='moa_mustard.jsonl', resume=False,
+                 sleep_between=0):
+    test_list = list(dataset.keys())
+
+    if resume:
+        processed = load_processed_keys(output_file)
+        test_list = [k for k in test_list if k not in processed]
+        print(f'Resume: {len(processed)} done, {len(test_list)} remaining')
+    else:
+        with open(output_file, 'w'):
+            pass
+
+    if not test_list:
+        print('Nothing to do.')
+        return
+
+    print('=' * 60)
+    print(f'MoA 1-round | Model: {MODEL}')
+    print(f'Samples: {len(test_list)} | Workers: {max_workers}')
+    print(f'Output: {output_file}')
+    print('=' * 60)
+
+    start_time = time.time()
+    completed = 0
+
+    if max_workers == 1 and sleep_between > 0:
+        for test_file in test_list:
+            try:
+                result = run_instance(test_file, dataset, dataset_name, output_file)
+                completed += 1
+                print(f'Progress: {completed}/{len(test_list)} - {result}')
+            except Exception as exc:
+                completed += 1
+                print(f'Error: {exc}')
+            if sleep_between > 0 and completed < len(test_list):
+                time.sleep(sleep_between)
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(run_instance, t, dataset, dataset_name, output_file): t
+                for t in test_list
+            }
+            for future in as_completed(futures):
+                completed += 1
+                try:
+                    result = future.result()
+                    print(f'Progress: {completed}/{len(test_list)} - {result}')
+                except Exception as exc:
+                    print(f'Error: {exc}')
+
+    wall_time = time.time() - start_time
+    _print_summary(output_file, wall_time)
+
+
+def _print_summary(output_file, wall_time):
+    total_api = total_pt = total_ct = total_tok = 0
+    latencies = []
+    stage_lats = {}
+    n = 0
+    try:
+        with open(output_file) as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                for _, val in json.loads(line).items():
+                    n += 1
+                    total_api += val.get('api_calls', 0)
+                    total_pt += val.get('prompt_tokens', 0)
+                    total_ct += val.get('completion_tokens', 0)
+                    total_tok += val.get('total_tokens', 0)
+                    latencies.append(val.get('latency', 0.0))
+                    for s, l in val.get('stage_latencies', {}).items():
+                        stage_lats.setdefault(s, []).append(l)
+    except Exception as e:
+        print(f'Warning: {e}')
+        return
+
+    if n == 0:
+        return
+
+    cost = total_pt / 1e6 * 0.075 + total_ct / 1e6 * 0.30
+    print(f'\n{"=" * 60}')
+    print(f'MOA PERFORMANCE & COST SUMMARY')
+    print(f'{"=" * 60}')
+    print(f'Samples:                  {n}')
+    print(f'Wall-clock:               {wall_time:.1f}s')
+    print(f'-' * 40)
+    print(f'Total API Calls:          {total_api}')
+    print(f'Avg API Calls/Sample:     {total_api / n:.1f}')
+    print(f'Avg Latency/Sample:       {sum(latencies) / n:.2f}s')
+    print(f'-' * 40)
+    print(f'Total Prompt Tokens:      {total_pt:,}')
+    print(f'Total Completion Tokens:  {total_ct:,}')
+    print(f'Total Tokens:             {total_tok:,}')
+    print(f'Avg Tokens/Sample:        {total_tok / n:,.0f}')
+    print(f'-' * 40)
+    print(f'Estimated Cost:           ${cost:.4f}')
+    print(f'Avg Cost/Sample:          ${cost / n:.6f}')
+    if stage_lats:
+        print(f'-' * 40)
+        print('Avg Latency by Stage:')
+        for s in sorted(stage_lats):
+            vals = stage_lats[s]
+            print(f'  {s:30s} {sum(vals)/len(vals):.2f}s')
+    print(f'{"=" * 60}\n')
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='MoA 1-round baseline for affective detection')
+    parser.add_argument('--dataset_name', type=str, default='mustard', choices=['urfunny', 'mustard'])
+    parser.add_argument('--dataset', type=str, default=None)
+    parser.add_argument('--output', type=str, default=None)
+    parser.add_argument('--max_workers', type=int, default=8)
+    parser.add_argument('--resume', action='store_true')
+    parser.add_argument('--sleep', type=float, default=0)
+    args = parser.parse_args()
+
+    config = get_dataset_config(args.dataset_name)
+    if args.dataset is None:
+        args.dataset = config.get_default_dataset_path()
+
+    # Load prompts for the target dataset
+    import sys as _sys
+    _this = _sys.modules[__name__]
+    _prompts = _load_ctm_prompts(args.dataset_name)
+    _this.TEXT_PROPOSER_SYSTEM = _prompts['language_processor']['system_prompt']
+    _this.AUDIO_PROPOSER_SYSTEM = _prompts['audio_processor']['system_prompt']
+    _this.VIDEO_PROPOSER_SYSTEM = _prompts['video_processor']['system_prompt']
+    _this.MOA_AGGREGATOR_SYSTEM = _get_aggregator_prompt(args.dataset_name)
+
+    output_file = args.output or f'moa_{args.dataset_name}_1round.jsonl'
+
+    dataset = load_data(args.dataset)
+    print(f'Dataset: {args.dataset_name} | Model: {MODEL} | Samples: {len(dataset)}')
+
+    run_parallel(
+        dataset, args.dataset_name,
+        max_workers=args.max_workers, output_file=output_file,
+        resume=args.resume, sleep_between=args.sleep,
+    )


### PR DESCRIPTION
Add three multi-agent baseline runners that share CTM-aligned system prompts and support both MUStARD (sarcasm) and URFunny (humor) datasets:

- run_moa.py: 1-layer MoA (3 modality proposers in parallel + 1 aggregator)
- run_metagpt.py: 4-stage SOP (3 analysts -> synthesizer -> critic -> judge)
- run_autogen.py: multi-round agent debate with tool-calling

Each runner loads processor system prompts from the dataset-specific CTM config (sarcasm_ctm_config.json for mustard, urfunny_test_qwen_v12_config.json for urfunny), so baselines stay aligned with the CTM framework being compared.

Also add urfunny_test_qwen_v12_config.json with humor-detection prompts for video, language, and audio processors.

<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [ ] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
