### PR TITLE
fix(affective): align MA baselines with CTM and parallelize runners

### DIFF
--- a/exp_affective/dataset_configs.py
+++ b/exp_affective/dataset_configs.py
@@ -120,32 +120,76 @@ class URFunnyConfig(DatasetConfig):
             'If you are not sure, please provide your best guess and do not say that you are not sure.'
         )
 
+    def get_modality_system_prompts(self) -> Dict[str, str]:
+        """Modality-specific expert system prompts, aligned with ctm_conf/urfunny_test_config.json."""
+        return {
+            'video': (
+                'You are an expert at analyzing visual cues in video frames. '
+                'Analyze the visual cues, body language, facial expressions, and context. '
+                'Note that the videos do not include audio, you should only analyze the visual cues. '
+                'Always ground your answer in specific visual observations. Be concise but thorough.'
+            ),
+            'text': (
+                'You are an expert at analyzing text and language. '
+                'You will receive a text transcript and a query. Analyze word choice and phrasing, '
+                'rhetorical devices, context and literal vs. intended meaning, and sentiment mismatch. '
+                'When the query is about specific textual details, provide precise analysis grounded in '
+                'the text. Always cite specific words or phrases as evidence. Be concise but thorough.'
+            ),
+            'audio': (
+                'You are an expert at analyzing audio. You will receive an audio file and a query. '
+                'Listen carefully to the audio and analyze the tone, emotion, pitch, speed, and vocal patterns. '
+                'Pay special attention to the tone of voice (flat, exaggerated, or ironic), pitch variations, '
+                'speaking speed, emphasis on certain words, and pauses and timing. Answer the query based on '
+                'your analysis of the audio. Explain your reasoning based on what you hear in the audio.'
+            ),
+        }
+
+    def get_aggregation_prompt(self) -> str:
+        """CTM-aligned final aggregation prompt (from urfunny_test_config parse_prompt_template)."""
+        return (
+            'You are a humor detection expert. Based solely on the analysis provided below, '
+            'determine if the punchline is humorous.\n\n'
+            'Your answer MUST start with either "Yes" (if humorous) or "No" (if not humorous), '
+            'followed by a brief explanation.\n\n'
+            'IMPORTANT: If the analysis expresses uncertainty, is inconclusive, or lacks sufficient '
+            'evidence, you should answer "No".'
+        )
+
     def get_debate_prompts(self) -> Dict[str, str]:
+        mod = self.get_modality_system_prompts()
         return {
             'video_init': (
-                'You are a Video Analysis Expert. You will analyze whether the person in the video is being humorous or not. Note that the video does not contain audio, you should just focus on the visual cues.\n'
+                f'{mod["video"]}\n\n'
+                'Task: Analyze whether the person in the video is being humorous or not, '
+                'based solely on the visual cues.\n'
                 "First, provide your analysis. Then, end your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'audio_init': (
-                'You are an Audio Analysis Expert. You will analyze whether the person in the audio is being humorous or not.\n'
+                f'{mod["audio"]}\n\n'
+                'Task: Analyze whether the person in the audio is being humorous or not.\n'
                 "First, provide your analysis. Then, end your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'text_init': (
-                'You are a Text Analysis Expert. You will be given a punchline that was said by a person, and analyze whether the person is being humorous or not.\n'
+                f'{mod["text"]}\n\n'
+                'Task: Analyze whether the target punchline is humorous.\n'
                 "First, provide your analysis. Then, end your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'video_refine': (
-                'You are a Video Analysis Expert. You previously analyzed the visual cues of a person in the video.\n'
+                f'{mod["video"]}\n\n'
+                'You previously analyzed the visual cues of the person in the video.\n'
                 'Your previous answer: {own_answer}\n\n'
                 'Here are the analyses from other experts:\n'
                 '- Audio Expert: {audio_answer}\n'
                 '- Text Expert: {text_answer}\n\n'
-                'First, consider their perspectives and re-examine the video evidence carefully. Note that the video does not contain audio, you should just focus on the visual cues.\n'
+                'First, consider their perspectives and re-examine the video evidence carefully. '
+                'Note that the video does not contain audio, you should just focus on the visual cues.\n'
                 'Then, determine if this punchline is humorous or not.\n'
                 "End your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'audio_refine': (
-                'You are an Audio Analysis Expert. You previously analyzed the audio of this punchline.\n'
+                f'{mod["audio"]}\n\n'
+                'You previously analyzed the audio of this punchline.\n'
                 'Your previous answer: {own_answer}\n\n'
                 'Here are the analyses from other experts:\n'
                 '- Video Expert: {video_answer}\n'
@@ -155,28 +199,32 @@ class URFunnyConfig(DatasetConfig):
                 "End your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'text_refine': (
-                'You are a Text Analysis Expert. You previously analyzed this punchline.\n'
+                f'{mod["text"]}\n\n'
+                'You previously analyzed this punchline.\n'
                 'Your previous answer: {own_answer}\n\n'
                 'Here are the analyses from other experts:\n'
                 '- Video Expert: {video_answer}\n'
                 '- Audio Expert: {audio_answer}\n\n'
-                'First, consider their perspectives and re-examine the text evidence of the punchline carefully.\n'
+                'First, consider their perspectives and re-examine the text evidence carefully.\n'
                 'Then, determine if this punchline is humorous or not.\n'
                 "End your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'judge': (
-                'You are an impartial Judge. Three experts have debated whether this punchline is humorous or not.\n'
-                'Here is the discussion:\n\n{debate_history}\n\n'
-                'Based on all evidence from the video, audio, and text analyses, determine if this punchline is humorous or not.\n'
-                "Your answer must start with 'Yes' or 'No', followed by your reasoning."
+                f'{self.get_aggregation_prompt()}\n\n'
+                'Three experts (Video, Audio, Text) have debated whether this punchline is humorous or not. '
+                'You must weigh all three experts equally — do not favor any single modality. '
+                "Evaluate the strength of each expert's evidence independently.\n\n"
+                'Analysis (debate history):\n{debate_history}'
             ),
         }
 
     def get_query_aug_prompts(self) -> Dict[str, str]:
+        mod = self.get_modality_system_prompts()
         return {
             'controller_init': (
                 'You are a Humor Detection Controller. Your task is to coordinate three modality experts '
                 '(Video, Audio, Text) to determine if the person is being humorous or not.\n\n'
+                'The target punchline is: \'{target_sentence}\'\n\n'
                 'For Round 1, generate THREE specific questions - one for each expert:\n'
                 '1. A question for the VIDEO expert to analyze visual expressions and gestures\n'
                 '2. A question for the AUDIO expert to analyze vocal tone and speech patterns\n'
@@ -201,27 +249,26 @@ class URFunnyConfig(DatasetConfig):
                 'TEXT_QUESTION: [your question]'
             ),
             'controller_decision': (
-                'You are a Humor Detection Controller. You have gathered evidence from three modality experts '
-                'over {num_rounds} rounds of questioning.\n\n'
-                'Here is the complete conversation history:\n{conversation_history}\n\n'
-                'Based on all the evidence gathered from video, audio, and text analyses, '
-                'determine if this person is being humorous or not.\n'
-                "Your answer must start with 'Yes' or 'No', followed by your reasoning."
+                f'{self.get_aggregation_prompt()}\n\n'
+                'You have gathered evidence from three modality experts (Video, Audio, Text) '
+                'over {num_rounds} rounds of questioning. Weigh all three experts equally — '
+                'do not favor any single modality.\n\n'
+                'Analysis (conversation history):\n{conversation_history}'
             ),
             'video_agent': (
-                'You are a Video Analysis Expert. You will analyze video frames showing a person. Note that the video does not contain audio, you should just focus on the visual cues.\n'
+                f'{mod["video"]}\n\n'
                 'Question: {question}\n\n'
                 "First, carefully observe and describe the person's visual expressions, gestures, and body language.\n"
                 'Then, based on your analysis, provide your answer to the question.'
             ),
             'audio_agent': (
-                'You are an Audio Analysis Expert. You will analyze audio of a person speaking.\n'
+                f'{mod["audio"]}\n\n'
                 'Question: {question}\n\n'
                 "First, carefully listen and describe the person's vocal tone, intonation, speech patterns, and any audio cues.\n"
                 'Then, based on your analysis, provide your answer to the question.'
             ),
             'text_agent': (
-                'You are a Text Analysis Expert. You will be given a punchline that was said by a person.\n'
+                f'{mod["text"]}\n\n'
                 'Question: {question}\n\n'
                 "Punchline: '{text}'\n\n"
                 'First, carefully read and analyze the text content, word choice, tone, and any linguistic patterns.\n'
@@ -292,32 +339,107 @@ class MustardConfig(DatasetConfig):
             'You should only make Yes judgement when you are very sure that the person is sarcastic.'
         )
 
+    def get_modality_system_prompts(self) -> Dict[str, str]:
+        """Modality-specific expert system prompts, aligned with ctm_conf/sarcasm_ctm_config.json.
+
+        Used by debate/orchestra/ensemble to ensure all MA baselines start from
+        the same expert knowledge as CTM — so cross-method comparison reflects
+        orchestration differences, not prompt-content differences.
+        """
+        return {
+            'video': (
+                'You are an expert at analyzing visual cues in video frames. '
+                'Analyze the visual cues, body language, facial expressions, and context. '
+                'Note that the videos do not include audio, you should only analyze the visual cues. '
+                'Always ground your answer in specific visual observations. Be concise but thorough.'
+            ),
+            'text': (
+                'You are an expert at analyzing text and language for sarcasm and irony. '
+                'You will receive a text transcript and a query. The LAST line is the target utterance; '
+                'preceding lines are conversation context. First identify what the CONTEXT is about, '
+                'then analyze whether the target utterance is sarcastic.\n\n'
+                'Analyze the utterance carefully in the context of the conversation: consider what was '
+                'said before, whether the statement contradicts the situation, and whether the speaker is '
+                'saying the opposite of what they mean. Look for verbal irony, understatement, hyperbole, '
+                'and absurd or impossible scenarios presented as serious explanations. Key distinctions: '
+                '(1) Genuine anger, frustration, or direct insults are NOT sarcasm even if they sound harsh. '
+                'A rhetorical question expressing real annoyance is not sarcastic. '
+                '(2) Sarcasm requires the speaker to mean the OPPOSITE of their literal words or to use '
+                'deliberate incongruity with the situation. '
+                '(3) Absurd statements that cannot be taken literally in context are likely sarcastic. '
+                '(4) Deadpan or dry humor — where the speaker says something absurd, exaggerated, or '
+                'contextually inappropriate with a straight-faced delivery — IS a form of sarcasm. If a '
+                'statement sounds normal on its own but is clearly ridiculous or incongruous given the '
+                'conversation context, it is likely sarcastic. '
+                '(5) Playful teasing where the speaker genuinely means what they say is NOT sarcasm. '
+                'Calling someone bad at something when they actually did something bad is genuine, not sarcastic. '
+                '(6) Genuine self-deprecation or honest emotional reactions (frustration, surprise, amusement) '
+                'are NOT sarcasm. '
+                "(7) Very short or simple responses ('Oh', 'Yeah', 'No') should NOT be classified as sarcastic "
+                'unless the context makes the meaning reversal unmistakable. '
+                'Always cite specific words or phrases as evidence. Be concise but thorough.'
+            ),
+            'audio': (
+                'You are an expert at analyzing audio. You will receive an audio file and a query. '
+                'Listen carefully to the audio and analyze the tone, emotion, pitch, speed, and vocal patterns. '
+                'Pay special attention to the tone of voice (flat, exaggerated, or ironic), pitch variations, '
+                'speaking speed, emphasis on certain words, and pauses and timing. Answer the query based on '
+                'your analysis of the audio. Explain your reasoning based on what you hear in the audio. '
+                'Key distinctions: '
+                '(1) A flat or dry delivery style does NOT automatically mean sarcasm — some people naturally '
+                'speak in a dry, deadpan manner. Only flag flat tone as sarcastic if it clearly contrasts with '
+                'emotionally charged content. '
+                '(2) Teasing, playful, or amused tones are not the same as sarcastic tones. '
+                '(3) If you cannot detect clear tonal markers of sarcasm, say so and rate your confidence lower '
+                'rather than guessing.'
+            ),
+        }
+
+    def get_aggregation_prompt(self) -> str:
+        """CTM-aligned final aggregation prompt (from parse_prompt_template)."""
+        return (
+            'You are a sarcasm detection expert. Based solely on the analysis provided below, '
+            'determine if the person is being sarcastic.\n\n'
+            'Your answer MUST start with either "Yes" (if sarcastic) or "No" (if not sarcastic), '
+            'followed by a brief explanation.\n\n'
+            'IMPORTANT: If the analysis expresses uncertainty, is inconclusive, or lacks sufficient '
+            'evidence, you should answer "No".'
+        )
+
     def get_debate_prompts(self) -> Dict[str, str]:
+        mod = self.get_modality_system_prompts()
         return {
             'video_init': (
-                'You are a Video Analysis Expert. You will analyze whether the person in the video is being sarcastic or not. Note that the video does not contain audio, you should just focus on the visual cues.\n'
+                f'{mod["video"]}\n\n'
+                'Task: Analyze whether the person in the video is being sarcastic or not, '
+                'based solely on the visual cues.\n'
                 "First, provide your analysis. Then, end your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'audio_init': (
-                'You are an Audio Analysis Expert. You will analyze whether the person in the audio is being sarcastic or not.\n'
+                f'{mod["audio"]}\n\n'
+                'Task: Analyze whether the person in the audio is being sarcastic or not.\n'
                 "First, provide your analysis. Then, end your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'text_init': (
-                'You are a Text Analysis Expert. You will be given an utterance that was said by a person, and analyze whether the person is being sarcastic or not.\n'
+                f'{mod["text"]}\n\n'
+                'Task: Analyze whether the target utterance is sarcastic.\n'
                 "First, provide your analysis. Then, end your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'video_refine': (
-                'You are a Video Analysis Expert. You previously analyzed the visual cues of a person in the video.\n'
+                f'{mod["video"]}\n\n'
+                'You previously analyzed the visual cues of the person in the video.\n'
                 'Your previous answer: {own_answer}\n\n'
                 'Here are the analyses from other experts:\n'
                 '- Audio Expert: {audio_answer}\n'
                 '- Text Expert: {text_answer}\n\n'
-                'First, consider their perspectives and re-examine the video evidence carefully. Note that the video does not contain audio, you should just focus on the visual cues.\n'
+                'First, consider their perspectives and re-examine the video evidence carefully. '
+                'Note that the video does not contain audio, you should just focus on the visual cues.\n'
                 'Then, determine if this utterance is sarcastic or not.\n'
                 "End your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'audio_refine': (
-                'You are an Audio Analysis Expert. You previously analyzed the audio of this utterance.\n'
+                f'{mod["audio"]}\n\n'
+                'You previously analyzed the audio of this utterance.\n'
                 'Your previous answer: {own_answer}\n\n'
                 'Here are the analyses from other experts:\n'
                 '- Video Expert: {video_answer}\n'
@@ -327,28 +449,32 @@ class MustardConfig(DatasetConfig):
                 "End your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'text_refine': (
-                'You are a Text Analysis Expert. You previously analyzed this utterance.\n'
+                f'{mod["text"]}\n\n'
+                'You previously analyzed this utterance.\n'
                 'Your previous answer: {own_answer}\n\n'
                 'Here are the analyses from other experts:\n'
                 '- Video Expert: {video_answer}\n'
                 '- Audio Expert: {audio_answer}\n\n'
-                'First, consider their perspectives and re-examine the text evidence of the utterance carefully.\n'
+                'First, consider their perspectives and re-examine the text evidence carefully.\n'
                 'Then, determine if this utterance is sarcastic or not.\n'
                 "End your response with 'My Answer: Yes' or 'My Answer: No'."
             ),
             'judge': (
-                'You are an impartial Judge. Three experts have debated whether this utterance is sarcastic or not.\n'
-                'Here is the discussion:\n\n{debate_history}\n\n'
-                'Based on all evidence from the video, audio, and text analyses, determine if this utterance is sarcastic or not.\n'
-                "Your answer must start with 'Yes' or 'No', followed by your reasoning."
+                f'{self.get_aggregation_prompt()}\n\n'
+                'Three experts (Video, Audio, Text) have debated whether this utterance is sarcastic or not. '
+                'You must weigh all three experts equally — do not favor any single modality. '
+                "Evaluate the strength of each expert's evidence independently.\n\n"
+                'Analysis (debate history):\n{debate_history}'
             ),
         }
 
     def get_query_aug_prompts(self) -> Dict[str, str]:
+        mod = self.get_modality_system_prompts()
         return {
             'controller_init': (
                 'You are a Sarcasm Detection Controller. Your task is to coordinate three modality experts '
                 '(Video, Audio, Text) to determine if the person is being sarcastic or not.\n\n'
+                'The target utterance is: \'{target_sentence}\'\n\n'
                 'For Round 1, generate THREE specific questions - one for each expert:\n'
                 '1. A question for the VIDEO expert to analyze visual expressions and gestures\n'
                 '2. A question for the AUDIO expert to analyze vocal tone and speech patterns\n'
@@ -373,27 +499,26 @@ class MustardConfig(DatasetConfig):
                 'TEXT_QUESTION: [your question]'
             ),
             'controller_decision': (
-                'You are a Sarcasm Detection Controller. You have gathered evidence from three modality experts '
-                'over {num_rounds} rounds of questioning.\n\n'
-                'Here is the complete conversation history:\n{conversation_history}\n\n'
-                'Based on all the evidence gathered from video, audio, and text analyses, '
-                'determine if this person is being sarcastic or not.\n'
-                "Your answer must start with 'Yes' or 'No', followed by your reasoning."
+                f'{self.get_aggregation_prompt()}\n\n'
+                'You have gathered evidence from three modality experts (Video, Audio, Text) '
+                'over {num_rounds} rounds of questioning. Weigh all three experts equally — '
+                'do not favor any single modality.\n\n'
+                'Analysis (conversation history):\n{conversation_history}'
             ),
             'video_agent': (
-                'You are a Video Analysis Expert. You will analyze video frames showing a person. Note that the video does not contain audio, you should just focus on the visual cues.\n'
+                f'{mod["video"]}\n\n'
                 'Question: {question}\n\n'
                 "First, carefully observe and describe the person's visual expressions, gestures, and body language.\n"
                 'Then, based on your analysis, provide your answer to the question.'
             ),
             'audio_agent': (
-                'You are an Audio Analysis Expert. You will analyze audio of a person speaking.\n'
+                f'{mod["audio"]}\n\n'
                 'Question: {question}\n\n'
                 "First, carefully listen and describe the person's vocal tone, intonation, speech patterns, and any audio cues.\n"
                 'Then, based on your analysis, provide your answer to the question.'
             ),
             'text_agent': (
-                'You are a Text Analysis Expert. You will be given an utterance that was said by a person.\n'
+                f'{mod["text"]}\n\n'
                 'Question: {question}\n\n'
                 "Utterance: '{text}'\n\n"
                 'First, carefully read and analyze the text content, word choice, tone, and any linguistic patterns.\n'

--- a/exp_affective/llm_utils.py
+++ b/exp_affective/llm_utils.py
@@ -16,7 +16,8 @@ import os
 import statistics
 import subprocess
 import tempfile
-from typing import Any, Dict, List, Optional, Tuple
+import threading
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import litellm
 from dataset_configs import get_dataset_config
@@ -38,14 +39,61 @@ QWEN_API_BASE = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
 # ============================================================================
 
 
-def check_api_key(provider: str = 'gemini'):
-    """Check if required API key environment variable is set"""
+def check_api_key(
+    provider: str = 'gemini', keys: Optional[Sequence[str]] = None
+):
+    """Check that at least one API key is available.
+
+    If `keys` is provided, use those; otherwise fall back to the standard
+    environment variable (GEMINI_API_KEY / DASHSCOPE_API_KEY).
+    """
+    if keys:
+        if any(k and k.strip() for k in keys):
+            return
+        raise ValueError(f'No valid {provider} API keys provided')
     if provider == 'gemini':
         if not os.getenv('GEMINI_API_KEY'):
             raise ValueError('GEMINI_API_KEY environment variable not set')
     elif provider == 'qwen':
         if not os.getenv('DASHSCOPE_API_KEY'):
             raise ValueError('DASHSCOPE_API_KEY environment variable not set')
+
+
+class KeyRotator:
+    """Thread-safe round-robin API key rotator.
+
+    Each call to `next()` returns the next key in the pool; rotation is
+    atomic so concurrent threads always get distinct sequential keys.
+    """
+
+    def __init__(self, keys: Sequence[str]):
+        self.keys: List[str] = [k.strip() for k in keys if k and k.strip()]
+        if not self.keys:
+            raise ValueError('KeyRotator: no non-empty keys provided')
+        self._idx = 0
+        self._lock = threading.Lock()
+
+    def next(self) -> str:
+        with self._lock:
+            k = self.keys[self._idx % len(self.keys)]
+            self._idx += 1
+            return k
+
+    def __len__(self) -> int:
+        return len(self.keys)
+
+
+def parse_api_keys(
+    api_keys_arg: Optional[str], provider: str = 'gemini'
+) -> List[str]:
+    """Parse --api-keys CLI arg (comma-separated) with env var fallback."""
+    if api_keys_arg:
+        keys = [k.strip() for k in api_keys_arg.split(',') if k.strip()]
+        if keys:
+            return keys
+    env_name = 'GEMINI_API_KEY' if provider == 'gemini' else 'DASHSCOPE_API_KEY'
+    env_val = os.getenv(env_name)
+    return [env_val] if env_val else []
 
 
 # ============================================================================
@@ -247,7 +295,11 @@ def build_video_content(video_path: str, provider: str = 'gemini') -> List[Dict]
 
 
 class BaseAgent:
-    """Base agent for LLM API calls with provider support"""
+    """Base agent for LLM API calls with provider support.
+
+    Thread-safe: a single agent instance can be shared across worker threads,
+    and each call rotates the API key via the shared KeyRotator (if provided).
+    """
 
     AGENT_TYPE = 'base'
 
@@ -256,10 +308,26 @@ class BaseAgent:
         provider: str = 'gemini',
         model: Optional[str] = None,
         temperature: float = 1.0,
+        api_key: Optional[str] = None,
+        key_rotator: Optional[KeyRotator] = None,
     ):
         self.provider = provider
         self.model = model or DEFAULT_MODELS.get(provider, DEFAULT_MODELS['gemini'])
         self.temperature = temperature
+        self.api_key = api_key
+        self.key_rotator = key_rotator
+
+    def _resolve_api_key(self) -> Optional[str]:
+        """Get an API key for this call. Rotates if a KeyRotator is set."""
+        if self.key_rotator is not None:
+            return self.key_rotator.next()
+        if self.api_key is not None:
+            return self.api_key
+        if self.provider == 'gemini':
+            return os.getenv('GEMINI_API_KEY')
+        if self.provider == 'qwen':
+            return os.getenv('DASHSCOPE_API_KEY')
+        return None
 
     def _build_content(self, query: str, **kwargs: Any) -> List[Dict]:
         """Build content list. Override in subclasses"""
@@ -268,7 +336,11 @@ class BaseAgent:
     def call(
         self, query: str, max_retries: int = 3, **kwargs: Any
     ) -> Tuple[Optional[str], Dict[str, int]]:
-        """Make an LLM API call with the agent's modality, retry up to max_retries on failure"""
+        """Make an LLM API call with the agent's modality, retry up to max_retries on failure.
+
+        On retry, the API key is re-resolved — so if multiple keys are provided
+        via KeyRotator, a failing key will be rotated away on the next attempt.
+        """
         content = self._build_content(query, **kwargs)
 
         for attempt in range(1, max_retries + 1):
@@ -277,10 +349,10 @@ class BaseAgent:
                     'model': self.model,
                     'messages': [{'role': 'user', 'content': content}],
                     'temperature': self.temperature,
+                    'api_key': self._resolve_api_key(),
                 }
 
                 if self.provider == 'qwen':
-                    call_kwargs['api_key'] = os.getenv('DASHSCOPE_API_KEY')
                     call_kwargs['api_base'] = QWEN_API_BASE
                     call_kwargs['modalities'] = ['text']
 
@@ -402,6 +474,8 @@ def create_agent(
     provider: str = 'gemini',
     model: Optional[str] = None,
     temperature: float = 1.0,
+    api_key: Optional[str] = None,
+    key_rotator: Optional[KeyRotator] = None,
 ) -> BaseAgent:
     """Factory function to create an agent by type"""
     if agent_type not in AGENT_CLASSES:
@@ -410,7 +484,11 @@ def create_agent(
             f'Choose from: {list(AGENT_CLASSES.keys())}'
         )
     return AGENT_CLASSES[agent_type](
-        provider=provider, model=model, temperature=temperature
+        provider=provider,
+        model=model,
+        temperature=temperature,
+        api_key=api_key,
+        key_rotator=key_rotator,
     )
 
 
@@ -449,8 +527,17 @@ def load_sample_inputs(
 
 def normalize_label(label) -> str:
     """Normalize label to 'Yes'/'No' format"""
+    if isinstance(label, bool):
+        return 'Yes' if label else 'No'
     if isinstance(label, (int, float)):
         return 'Yes' if label == 1 else 'No'
+    if isinstance(label, str):
+        lower = label.strip().lower()
+        if lower in ('yes', 'true', '1'):
+            return 'Yes'
+        if lower in ('no', 'false', '0'):
+            return 'No'
+        return label
     return str(label)
 
 
@@ -460,7 +547,7 @@ def normalize_label(label) -> str:
 
 
 class StatsTracker:
-    """Track performance statistics across multiple samples"""
+    """Track performance statistics across multiple samples (thread-safe)"""
 
     def __init__(
         self,
@@ -474,6 +561,7 @@ class StatsTracker:
         self.api_calls: List[int] = []
         self.cost_input_per_1m = cost_input_per_1m
         self.cost_output_per_1m = cost_output_per_1m
+        self._lock = threading.Lock()
 
     def add(
         self,
@@ -486,11 +574,12 @@ class StatsTracker:
         cost = (input_tok / 1_000_000 * self.cost_input_per_1m) + (
             output_tok / 1_000_000 * self.cost_output_per_1m
         )
-        self.times.append(duration)
-        self.input_tokens.append(input_tok)
-        self.output_tokens.append(output_tok)
-        self.costs.append(cost)
-        self.api_calls.append(num_api_calls)
+        with self._lock:
+            self.times.append(duration)
+            self.input_tokens.append(input_tok)
+            self.output_tokens.append(output_tok)
+            self.costs.append(cost)
+            self.api_calls.append(num_api_calls)
 
     def print_summary(self, method_name: str = 'Experiment'):
         """Print summary statistics"""
@@ -529,10 +618,27 @@ class StatsTracker:
 # ============================================================================
 
 
+_jsonl_write_locks: Dict[str, threading.Lock] = {}
+_jsonl_write_locks_lock = threading.Lock()
+
+
+def _get_jsonl_lock(output_file: str) -> threading.Lock:
+    """Return a per-file threading lock (created lazily)."""
+    with _jsonl_write_locks_lock:
+        lock = _jsonl_write_locks.get(output_file)
+        if lock is None:
+            lock = threading.Lock()
+            _jsonl_write_locks[output_file] = lock
+        return lock
+
+
 def save_result_to_jsonl(result: dict, output_file: str):
-    """Append result dictionary to JSONL file"""
-    with open(output_file, 'a', encoding='utf-8') as f:
-        f.write(json.dumps(result, ensure_ascii=False) + '\n')
+    """Append result dictionary to JSONL file (thread-safe per output_file)."""
+    lock = _get_jsonl_lock(output_file)
+    line = json.dumps(result, ensure_ascii=False) + '\n'
+    with lock:
+        with open(output_file, 'a', encoding='utf-8') as f:
+            f.write(line)
 
 
 # ============================================================================
@@ -579,5 +685,20 @@ def add_common_args(parser):
         type=float,
         default=1.0,
         help='Sampling temperature (default: 1.0)',
+    )
+    parser.add_argument(
+        '--max-workers',
+        type=int,
+        default=4,
+        help='Number of samples to process concurrently (default: 4)',
+    )
+    parser.add_argument(
+        '--api-keys',
+        type=str,
+        default=None,
+        help=(
+            'Comma-separated list of API keys to rotate across. '
+            'If omitted, falls back to the GEMINI_API_KEY / DASHSCOPE_API_KEY env var.'
+        ),
     )
     return parser

--- a/exp_affective/reextract_votes.py
+++ b/exp_affective/reextract_votes.py
@@ -1,0 +1,148 @@
+"""Post-process JSONL output files to re-extract votes/answers from the stored
+raw responses, using the updated extract_vote / extract_answer logic.
+
+Use case: the running experiments stored valid `individual_answers` (or
+`debate_history` / `conversation_history`) but some `final_vote` / `answer`
+fields were computed with an older, too-strict extractor and show Unknown.
+
+Re-extraction does NOT make new API calls — it operates only on the stored
+response text.
+
+Usage:
+    python reextract_votes.py runs_mustard_fix/ensemble_mustard_gemini.jsonl
+    python reextract_votes.py runs_mustard_fix/*.jsonl
+"""
+
+import argparse
+import json
+from collections import Counter
+
+from llm_utils import normalize_label
+from run_debate import extract_answer
+from run_ensemble import extract_vote, majority_vote
+
+
+def fix_ensemble_entry(entry):
+    """Return (new_entry, changed) for an ensemble result."""
+    individual = entry.get('individual_answers', {})
+    agent_types = ['text', 'audio', 'video']
+    new_votes = {t: extract_vote(individual.get(t)) for t in agent_types}
+    votes_list = [new_votes[t] for t in agent_types]
+    new_final = majority_vote(votes_list)
+    new_dist = dict(Counter(votes_list))
+    label_norm = normalize_label(entry.get('label'))
+    new_correct = new_final == label_norm
+
+    changed = (
+        new_votes != entry.get('votes')
+        or new_final != entry.get('final_vote')
+        or new_dist != entry.get('vote_distribution')
+        or label_norm != entry.get('label_normalized')
+        or new_correct != entry.get('correct')
+    )
+    if changed:
+        entry['votes'] = new_votes
+        entry['final_vote'] = new_final
+        entry['vote_distribution'] = new_dist
+        entry['label_normalized'] = label_norm
+        entry['correct'] = new_correct
+        entry['answer'] = [new_final]
+    return entry, changed
+
+
+def fix_debate_entry(entry):
+    """Return (new_entry, changed) for a debate result.
+
+    Debate stores `answer` as [judge_verdict_text] and `final_votes` as the
+    per-agent last-round votes extracted from debate_history.
+    """
+    changed = False
+    # Re-extract final_votes from debate_history if stored there
+    history = entry.get('debate_history', '')
+    # The debate_history is a concatenated text of "[Agent Expert]: <response>"
+    # Last round's votes are already-stored in final_votes; we leave those
+    # alone unless the judge verdict itself is unparseable.
+    judge = entry.get('answer', [None])[0]
+    if judge:
+        new_parsed = extract_answer(judge)
+        old_parsed = entry.get('parsed_verdict')
+        if new_parsed != old_parsed:
+            entry['parsed_verdict'] = new_parsed
+            changed = True
+    # Also re-extract final_votes (best effort) — just pass through.
+    return entry, changed
+
+
+def fix_orchestra_entry(entry):
+    """Return (new_entry, changed) for an orchestra result."""
+    changed = False
+    decision = entry.get('answer', [None])[0]
+    if decision:
+        new_parsed = extract_answer(decision)
+        old_parsed = entry.get('parsed_verdict')
+        if new_parsed != old_parsed:
+            entry['parsed_verdict'] = new_parsed
+            changed = True
+    return entry, changed
+
+
+def detect_method(entry_value):
+    method = entry_value.get('method', '')
+    if 'ensemble' in method:
+        return 'ensemble'
+    if 'debate' in method:
+        return 'debate'
+    if 'orchestra' in method:
+        return 'orchestra'
+    return None
+
+
+def process_file(path, dry_run=False):
+    method_counts = Counter()
+    total = 0
+    changed_count = 0
+    out_lines = []
+
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            key = next(iter(obj.keys()))
+            value = obj[key]
+            method = detect_method(value)
+            method_counts[method] += 1
+            total += 1
+
+            if method == 'ensemble':
+                value, ch = fix_ensemble_entry(value)
+            elif method == 'debate':
+                value, ch = fix_debate_entry(value)
+            elif method == 'orchestra':
+                value, ch = fix_orchestra_entry(value)
+            else:
+                ch = False
+
+            if ch:
+                changed_count += 1
+            obj[key] = value
+            out_lines.append(json.dumps(obj, ensure_ascii=False) + '\n')
+
+    print(f'{path}: {total} entries, methods={dict(method_counts)}, changed={changed_count}')
+
+    if not dry_run and changed_count > 0:
+        tmp = path + '.tmp'
+        with open(tmp, 'w', encoding='utf-8') as f:
+            f.writelines(out_lines)
+        import os
+        os.replace(tmp, path)
+        print(f'  -> wrote {path}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Re-extract votes from JSONL output')
+    parser.add_argument('files', nargs='+', help='JSONL files to fix in place')
+    parser.add_argument('--dry-run', action='store_true', help='Do not write changes')
+    args = parser.parse_args()
+    for f in args.files:
+        process_file(f, dry_run=args.dry_run)

--- a/exp_affective/run_debate.py
+++ b/exp_affective/run_debate.py
@@ -11,18 +11,21 @@ python run_debate.py --dataset_name mustard --provider gemini --rounds 3
 
 import argparse
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import litellm
 from dataset_configs import get_dataset_config
 from llm_utils import (
+    KeyRotator,
     StatsTracker,
     check_api_key,
     create_agent,
     load_data,
     load_processed_keys,
     load_sample_inputs,
+    parse_api_keys,
     save_result_to_jsonl,
 )
 
@@ -34,18 +37,40 @@ COST_OUTPUT_PER_1M = 0.30
 
 
 def extract_answer(response):
-    """Extract Yes/No from agent response."""
-    if response is None:
+    """Extract Yes/No from agent response.
+
+    Tries (in order):
+      1. Explicit 'my answer: yes/no' marker
+      2. LAST line that starts with yes/no (CTM text prompt style:
+         "context...\\n\\nYes, ...")
+      3. Last non-empty line ending with yes/no
+    """
+    if response is None or not response.strip():
         return 'Unknown'
     lower = response.lower()
+    # 1. Explicit marker
     if 'my answer: yes' in lower:
         return 'Yes'
-    elif 'my answer: no' in lower:
+    if 'my answer: no' in lower:
         return 'No'
-    if lower.strip().endswith('yes'):
-        return 'Yes'
-    elif lower.strip().endswith('no'):
-        return 'No'
+    lines = [ln.strip() for ln in lower.splitlines() if ln.strip()]
+    # 2. Scan from the END for a line starting with yes/no
+    for line in reversed(lines):
+        toks = line.split()
+        if not toks:
+            continue
+        first_word = toks[0].rstrip('.!?,:;"\'')
+        if first_word == 'yes':
+            return 'Yes'
+        if first_word == 'no':
+            return 'No'
+    # 3. Last line ends with yes/no
+    if lines:
+        last = lines[-1].rstrip('.!?"\' ')
+        if last.endswith(' yes') or last == 'yes':
+            return 'Yes'
+        if last.endswith(' no') or last == 'no':
+            return 'No'
     return 'Unknown'
 
 
@@ -226,6 +251,18 @@ if __name__ == '__main__':
         default=3,
         help='Number of debate rounds (default: 3)',
     )
+    parser.add_argument(
+        '--max-workers',
+        type=int,
+        default=4,
+        help='Number of samples to process concurrently (default: 4)',
+    )
+    parser.add_argument(
+        '--api-keys',
+        type=str,
+        default=None,
+        help='Comma-separated API keys to rotate across (default: env var)',
+    )
     args = parser.parse_args()
 
     ROUNDS = args.rounds
@@ -235,24 +272,42 @@ if __name__ == '__main__':
         args.dataset = config.get_default_dataset_path()
     output_file = args.output or f'debate_{args.dataset_name}_{args.provider}.jsonl'
 
-    check_api_key(args.provider)
+    api_keys = parse_api_keys(args.api_keys, args.provider)
+    check_api_key(args.provider, keys=api_keys)
     litellm.set_verbose = False
 
     tracker = StatsTracker(
         cost_input_per_1m=COST_INPUT_PER_1M, cost_output_per_1m=COST_OUTPUT_PER_1M
     )
+    rotator = KeyRotator(api_keys) if len(api_keys) > 1 else None
 
     video_agent = create_agent(
-        'video', provider=args.provider, model=args.model, temperature=args.temperature
+        'video',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     audio_agent = create_agent(
-        'audio', provider=args.provider, model=args.model, temperature=args.temperature
+        'audio',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     text_agent = create_agent(
-        'text', provider=args.provider, model=args.model, temperature=args.temperature
+        'text',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     print(
-        f'Dataset: {args.dataset_name} | Provider: {args.provider} | Model: {text_agent.model}'
+        f'Dataset: {args.dataset_name} | Provider: {args.provider} | Model: {text_agent.model} '
+        f'| keys={len(api_keys)} | workers={args.max_workers}'
     )
 
     dataset = load_data(args.dataset)
@@ -263,24 +318,37 @@ if __name__ == '__main__':
             f'Resuming: {len(processed_keys)} done, {len(test_list) - len(processed_keys)} remaining'
         )
 
+    pending = [tf for tf in test_list if tf not in processed_keys]
+    progress_lock = threading.Lock()
+    done_counter = [0]
+    total_pending = len(pending)
+
+    def worker(test_file):
+        try:
+            run_instance(
+                test_file,
+                dataset,
+                args.dataset_name,
+                video_agent,
+                audio_agent,
+                text_agent,
+                tracker,
+                output_file,
+            )
+        except Exception as e:
+            print(f'[ERROR] {test_file}: {e}')
+        finally:
+            with progress_lock:
+                done_counter[0] += 1
+                if done_counter[0] % 10 == 0 or done_counter[0] == total_pending:
+                    print(
+                        f'[progress] {done_counter[0]}/{total_pending} samples done'
+                    )
+
     try:
-        for test_file in test_list:
-            if test_file in processed_keys:
-                continue
-            try:
-                run_instance(
-                    test_file,
-                    dataset,
-                    args.dataset_name,
-                    video_agent,
-                    audio_agent,
-                    text_agent,
-                    tracker,
-                    output_file,
-                )
-            except Exception as e:
-                print(f'[ERROR] {test_file}: {e}')
-                continue
-            time.sleep(2)
+        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            futures = [executor.submit(worker, tf) for tf in pending]
+            for fut in as_completed(futures):
+                fut.result()
     finally:
         tracker.print_summary(f'Debate - {ROUNDS} Rounds')

--- a/exp_affective/run_ensemble.py
+++ b/exp_affective/run_ensemble.py
@@ -15,9 +15,12 @@ import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import threading
+
 import litellm
 from dataset_configs import get_dataset_config
 from llm_utils import (
+    KeyRotator,
     StatsTracker,
     check_api_key,
     create_agent,
@@ -25,6 +28,7 @@ from llm_utils import (
     load_processed_keys,
     load_sample_inputs,
     normalize_label,
+    parse_api_keys,
     save_result_to_jsonl,
 )
 
@@ -35,23 +39,80 @@ COST_OUTPUT_PER_1M = 0.30
 
 
 def extract_vote(answer):
-    """Extract Yes/No from the answer."""
+    """Extract Yes/No from the answer.
+
+    The CTM-aligned text system prompt asks the agent to "first identify the
+    CONTEXT, then analyze", so responses often have two paragraphs:
+      1. "The context is ..."  (not a yes/no answer)
+      2. "Yes, <reasoning>..."  OR  "<Speaker>'s statement is sarcastic..."
+
+    Tries (in order):
+      1. Explicit 'my answer: yes/no' marker
+      2. LAST line that starts with yes/no
+      3. Last non-empty line ends with yes/no
+      4. Phrase-based fallback for task-specific conclusions
+         ('not sarcastic' / 'is sarcastic' / 'is humorous' / 'not humorous')
+    """
     if answer is None or not answer.strip():
         return 'Unknown'
-    first_line = answer.strip().split('\n')[0].strip().lower()
-    first_word = first_line.split()[0] if first_line.split() else ''
-    if first_word == 'yes' or answer.strip().lower().startswith('yes'):
+    lower = answer.strip().lower()
+    # 1. Explicit marker (highest priority)
+    if 'my answer: yes' in lower:
         return 'Yes'
-    elif first_word == 'no' or answer.strip().lower().startswith('no'):
+    if 'my answer: no' in lower:
         return 'No'
+    lines = [ln.strip() for ln in lower.splitlines() if ln.strip()]
+    # 2. Scan from the END for the first line that starts with yes/no
+    for line in reversed(lines):
+        toks = line.split()
+        if not toks:
+            continue
+        first_word = toks[0].rstrip('.!?,:;"\'')
+        if first_word == 'yes':
+            return 'Yes'
+        if first_word == 'no':
+            return 'No'
+    # 3. Last line ends with yes/no (rare: "the answer is yes")
+    if lines:
+        last = lines[-1].rstrip('.!?"\' ')
+        if last.endswith(' yes') or last == 'yes':
+            return 'Yes'
+        if last.endswith(' no') or last == 'no':
+            return 'No'
+    # 4. Phrase-based fallback (task-specific). Check negations first so
+    #    "not sarcastic" doesn't trigger "sarcastic".
+    negations = (
+        'not sarcastic', "isn't sarcastic", 'is not sarcastic',
+        'not being sarcastic', 'no sarcasm', 'not humorous',
+        "isn't humorous", 'is not humorous', 'not being humorous',
+        'not a joke', 'not humor',
+    )
+    affirmatives = (
+        'is sarcastic', 'being sarcastic', 'are sarcastic',
+        'sarcasm is present', 'a form of sarcasm', 'is sarcasm',
+        'is humorous', 'being humorous', 'are humorous',
+        'is humor', 'a joke', 'humor is present',
+    )
+    if any(n in lower for n in negations):
+        return 'No'
+    if any(a in lower for a in affirmatives):
+        return 'Yes'
     return 'Unknown'
 
 
 def majority_vote(votes):
-    """Return the majority vote result."""
-    counts = Counter(votes)
-    most_common = counts.most_common(1)
-    return most_common[0][0] if most_common else 'Unknown'
+    """Return the majority vote, ignoring Unknown votes.
+
+    If all votes are Unknown, returns Unknown. Otherwise picks the most
+    common valid vote; ties are broken in insertion order (so a consistent
+    agent ordering produces consistent tie-breaks across runs).
+    """
+    valid = [v for v in votes if v != 'Unknown']
+    if not valid:
+        return 'Unknown'
+    return Counter(valid).most_common(1)[0][0]
+
+
 
 
 def run_instance(
@@ -70,12 +131,22 @@ def run_instance(
     # Step 1: Load inputs
     inputs = load_sample_inputs(test_file, dataset, dataset_name)
     target_sentence = inputs['target_sentence']
-    system_prompt = inputs['system_prompt']
     label = inputs['label']
     muted_video_path = inputs['muted_video_path']
     audio_path = inputs['audio_path']
+    config = inputs['config']
 
-    query = f"{system_prompt}\n\ntarget text: '{target_sentence}'"
+    # Use CTM-aligned modality-specific system prompts + task query, so ensemble
+    # starts from the same expert knowledge as debate/orchestra/CTM.
+    mod = config.get_modality_system_prompts()
+    task_query = (
+        f'Task: {config.get_task_query()}\n'
+        "Your answer must start with 'Yes' or 'No', followed by your reasoning. "
+        'If you are unsure or the evidence is inconclusive, answer "No".'
+    )
+    text_query = f"{mod['text']}\n\n{task_query}\n\ntarget text: '{target_sentence}'"
+    audio_query = f"{mod['audio']}\n\n{task_query}"
+    video_query = f"{mod['video']}\n\n{task_query}"
 
     print(f'--- Modality Ensemble for {test_file} ---')
 
@@ -85,11 +156,11 @@ def run_instance(
 
     def run_agent(agent_type):
         if agent_type == 'text':
-            return agent_type, *text_agent.call(query)
+            return agent_type, *text_agent.call(text_query)
         elif agent_type == 'audio':
-            return agent_type, *audio_agent.call(query, audio_path=audio_path)
+            return agent_type, *audio_agent.call(audio_query, audio_path=audio_path)
         elif agent_type == 'video':
-            return agent_type, *video_agent.call(query, video_path=muted_video_path)
+            return agent_type, *video_agent.call(video_query, video_path=muted_video_path)
 
     agent_types = ['text', 'audio', 'video']
     all_answers = {}
@@ -192,6 +263,18 @@ if __name__ == '__main__':
         default=1.0,
         help='Sampling temperature (default: 1.0)',
     )
+    parser.add_argument(
+        '--max-workers',
+        type=int,
+        default=4,
+        help='Number of samples to process concurrently (default: 4)',
+    )
+    parser.add_argument(
+        '--api-keys',
+        type=str,
+        default=None,
+        help='Comma-separated API keys to rotate across (default: env var)',
+    )
     args = parser.parse_args()
 
     config = get_dataset_config(args.dataset_name)
@@ -199,26 +282,46 @@ if __name__ == '__main__':
         args.dataset = config.get_default_dataset_path()
     output_file = args.output or f'ensemble_{args.dataset_name}_{args.provider}.jsonl'
 
-    check_api_key(args.provider)
+    api_keys = parse_api_keys(args.api_keys, args.provider)
+    check_api_key(args.provider, keys=api_keys)
     litellm.set_verbose = False
 
     tracker = StatsTracker(
         cost_input_per_1m=COST_INPUT_PER_1M, cost_output_per_1m=COST_OUTPUT_PER_1M
     )
+    rotator = KeyRotator(api_keys) if len(api_keys) > 1 else None
 
     text_agent = create_agent(
-        'text', provider=args.provider, model=args.model, temperature=args.temperature
+        'text',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     audio_agent = create_agent(
-        'audio', provider=args.provider, model=args.model, temperature=args.temperature
+        'audio',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     video_agent = create_agent(
-        'video', provider=args.provider, model=args.model, temperature=args.temperature
+        'video',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     print(
         f'Dataset: {args.dataset_name} | Provider: {args.provider} | Model: {text_agent.model}'
     )
-    print(f'Agents: TextAgent + AudioAgent + VideoAgent -> Majority Vote')
+    print(
+        f'Agents: TextAgent + AudioAgent + VideoAgent -> Majority Vote '
+        f'| keys={len(api_keys)} | workers={args.max_workers}'
+    )
 
     dataset = load_data(args.dataset)
     test_list = list(dataset.keys())
@@ -228,24 +331,37 @@ if __name__ == '__main__':
             f'Resuming: {len(processed_keys)} done, {len(test_list) - len(processed_keys)} remaining'
         )
 
+    pending = [tf for tf in test_list if tf not in processed_keys]
+    progress_lock = threading.Lock()
+    done_counter = [0]
+    total_pending = len(pending)
+
+    def worker(test_file):
+        try:
+            run_instance(
+                test_file,
+                dataset,
+                args.dataset_name,
+                text_agent,
+                audio_agent,
+                video_agent,
+                tracker,
+                output_file,
+            )
+        except Exception as e:
+            print(f'[ERROR] {test_file}: {e}')
+        finally:
+            with progress_lock:
+                done_counter[0] += 1
+                if done_counter[0] % 10 == 0 or done_counter[0] == total_pending:
+                    print(
+                        f'[progress] {done_counter[0]}/{total_pending} samples done'
+                    )
+
     try:
-        for test_file in test_list:
-            if test_file in processed_keys:
-                continue
-            try:
-                run_instance(
-                    test_file,
-                    dataset,
-                    args.dataset_name,
-                    text_agent,
-                    audio_agent,
-                    video_agent,
-                    tracker,
-                    output_file,
-                )
-            except Exception as e:
-                print(f'[ERROR] {test_file}: {e}')
-                continue
-            time.sleep(2)
+        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            futures = [executor.submit(worker, tf) for tf in pending]
+            for fut in as_completed(futures):
+                fut.result()
     finally:
         tracker.print_summary('Modality Ensemble (Text+Audio+Video)')

--- a/exp_affective/run_orchestra.py
+++ b/exp_affective/run_orchestra.py
@@ -12,18 +12,21 @@ python run_orchestra.py --dataset_name mustard --provider gemini --rounds 3
 
 import argparse
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import litellm
 from dataset_configs import get_dataset_config
 from llm_utils import (
+    KeyRotator,
     StatsTracker,
     check_api_key,
     create_agent,
     load_data,
     load_processed_keys,
     load_sample_inputs,
+    parse_api_keys,
     save_result_to_jsonl,
 )
 
@@ -108,7 +111,9 @@ def run_instance(
 
         # Controller generates questions
         if round_num == 1:
-            controller_query = prompts['controller_init']
+            controller_query = prompts['controller_init'].format(
+                target_sentence=target_sentence
+            )
         else:
             controller_query = prompts['controller_followup'].format(
                 prev_round=round_num - 1,
@@ -162,8 +167,9 @@ def run_instance(
         print(f'    Text:  {text_response[:60] if text_response else "None"}...')
 
     # Controller final decision
-    decision_query = prompts['controller_decision'].format(
-        num_rounds=ROUNDS, conversation_history=conversation_history
+    decision_query = (
+        f"{prompts['controller_decision'].format(num_rounds=ROUNDS, conversation_history=conversation_history)}"
+        f"\n\ntarget text: '{target_sentence}'"
     )
     final_verdict, usage = text_agent.call(decision_query)
     num_api_calls += 1
@@ -244,6 +250,18 @@ if __name__ == '__main__':
         default=3,
         help='Number of questioning rounds (default: 3)',
     )
+    parser.add_argument(
+        '--max-workers',
+        type=int,
+        default=4,
+        help='Number of samples to process concurrently (default: 4)',
+    )
+    parser.add_argument(
+        '--api-keys',
+        type=str,
+        default=None,
+        help='Comma-separated API keys to rotate across (default: env var)',
+    )
     args = parser.parse_args()
 
     ROUNDS = args.rounds
@@ -253,24 +271,42 @@ if __name__ == '__main__':
         args.dataset = config.get_default_dataset_path()
     output_file = args.output or f'orchestra_{args.dataset_name}_{args.provider}.jsonl'
 
-    check_api_key(args.provider)
+    api_keys = parse_api_keys(args.api_keys, args.provider)
+    check_api_key(args.provider, keys=api_keys)
     litellm.set_verbose = False
 
     tracker = StatsTracker(
         cost_input_per_1m=COST_INPUT_PER_1M, cost_output_per_1m=COST_OUTPUT_PER_1M
     )
+    rotator = KeyRotator(api_keys) if len(api_keys) > 1 else None
 
     video_agent = create_agent(
-        'video', provider=args.provider, model=args.model, temperature=args.temperature
+        'video',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     audio_agent = create_agent(
-        'audio', provider=args.provider, model=args.model, temperature=args.temperature
+        'audio',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     text_agent = create_agent(
-        'text', provider=args.provider, model=args.model, temperature=args.temperature
+        'text',
+        provider=args.provider,
+        model=args.model,
+        temperature=args.temperature,
+        api_key=api_keys[0] if api_keys else None,
+        key_rotator=rotator,
     )
     print(
-        f'Dataset: {args.dataset_name} | Provider: {args.provider} | Model: {text_agent.model}'
+        f'Dataset: {args.dataset_name} | Provider: {args.provider} | Model: {text_agent.model} '
+        f'| keys={len(api_keys)} | workers={args.max_workers}'
     )
 
     dataset = load_data(args.dataset)
@@ -281,24 +317,37 @@ if __name__ == '__main__':
             f'Resuming: {len(processed_keys)} done, {len(test_list) - len(processed_keys)} remaining'
         )
 
+    pending = [tf for tf in test_list if tf not in processed_keys]
+    progress_lock = threading.Lock()
+    done_counter = [0]
+    total_pending = len(pending)
+
+    def worker(test_file):
+        try:
+            run_instance(
+                test_file,
+                dataset,
+                args.dataset_name,
+                video_agent,
+                audio_agent,
+                text_agent,
+                tracker,
+                output_file,
+            )
+        except Exception as e:
+            print(f'[ERROR] {test_file}: {e}')
+        finally:
+            with progress_lock:
+                done_counter[0] += 1
+                if done_counter[0] % 10 == 0 or done_counter[0] == total_pending:
+                    print(
+                        f'[progress] {done_counter[0]}/{total_pending} samples done'
+                    )
+
     try:
-        for test_file in test_list:
-            if test_file in processed_keys:
-                continue
-            try:
-                run_instance(
-                    test_file,
-                    dataset,
-                    args.dataset_name,
-                    video_agent,
-                    audio_agent,
-                    text_agent,
-                    tracker,
-                    output_file,
-                )
-            except Exception as e:
-                print(f'[ERROR] {test_file}: {e}')
-                continue
-            time.sleep(2)
+        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            futures = [executor.submit(worker, tf) for tf in pending]
+            for fut in as_completed(futures):
+                fut.result()
     finally:
         tracker.print_summary(f'Orchestra - {ROUNDS} Rounds')


### PR DESCRIPTION
Fairness: the multi-agent baselines (debate/orchestra/ensemble) now use the same modality-specific expert system prompts and the same conservative aggregation rule as the CTM processors in ctm_conf/sarcasm_ctm_config.json and urfunny_test_config.json. Cross-method differences should reflect the orchestration mechanism, not prompt-content gaps.

Correctness fixes on top of the CTM alignment:
- orchestra controller_decision now receives target_sentence (was only seeing second-hand agent summaries)
- orchestra controller_init receives target_sentence so round-1 questions are grounded in the actual utterance
- ensemble preserves modality isolation (only the text agent sees target_sentence; audio/video agents see media only)
- debate judge prompt explicitly weighs all three experts equally
- extract_answer / extract_vote handle the CTM text-prompt pattern ("context first, then answer") via a last-line-starts-with scan and a phrase-based fallback ("is sarcastic"/"not sarcastic")
- majority_vote ignores Unknown votes instead of letting them tie-break
- normalize_label handles bool/int/str explicitly

Runner refactor (exp_affective/run_{debate,orchestra,ensemble}.py):
- add --max-workers for sample-level concurrency via ThreadPoolExecutor
- add --api-keys for comma-separated key rotation
- drop time.sleep(2) between samples (the old serialization bottleneck)
- thread-safe StatsTracker and save_result_to_jsonl via per-file locks
- KeyRotator (round-robin) in llm_utils.py, rotates on each retry so a failing key is swapped out automatically

Also adds reextract_votes.py: a post-processor that re-runs vote extraction on stored individual_answers / answer fields without making new API calls, used to retroactively fix Unknown results after extractor improvements.

<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [ ] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
