### PR TITLE
refactor(ctm): promote efficient link_form/fuse to base + bug fixes

### DIFF
--- a/ctm_ai/ctms/ctm.py
+++ b/ctm_ai/ctms/ctm.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import os
 from typing import Any, List, Optional, Tuple
@@ -20,13 +21,25 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
         api_manager: When supplied, tool processors are registered from the
             available functions in this manager (tool-use mode).
         num_additional_questions: Override the config value if given.
+        detailed_log_dir: Directory where per-instance trajectories are saved
+            (defaults to ``detailed_info/``).
     """
+
+    # Default link formation relevance threshold.
+    LINK_FORM_THRESHOLD: float = 0.8
+
+    # Whether the winning processor is also queried during link_form
+    # (and whether a winner→winner edge may be added to the graph).
+    # Default False — matches the efficient behavior of skipping the winner.
+    LINK_FORM_ASK_SELF: bool = False
 
     def __init__(
         self,
         ctm_name: Optional[str] = None,
         api_manager: Any = None,
         num_additional_questions: Optional[int] = None,
+        *,
+        detailed_log_dir: Optional[str] = None,
     ) -> None:
         self.api_manager = api_manager
         self.config = (
@@ -38,6 +51,17 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
             self.config.num_additional_questions = num_additional_questions
         self.iteration_history: list = []
         self.detailed_log = None
+        self.detailed_log_dir = detailed_log_dir
+
+        # Usage / link counters (populated per forward call).
+        self._iter_links_added = 0
+        self._total_links_added = 0
+        self._parse_usage = {
+            'prompt_tokens': 0,
+            'completion_tokens': 0,
+            'total_tokens': 0,
+        }
+
         self.load_ctm()
 
     def __call__(
@@ -97,12 +121,220 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
             )
 
     # ------------------------------------------------------------------
-    # CTM phases
+    # Usage tracking
+    # ------------------------------------------------------------------
+
+    def get_usage_stats(self):
+        """Aggregate usage stats across processors (excludes parse step)."""
+        total = {
+            'prompt_tokens': 0,
+            'completion_tokens': 0,
+            'total_tokens': 0,
+            'api_calls': 0,
+        }
+        for proc in self.processor_graph.nodes:
+            for k in total:
+                total[k] += proc._usage_stats.get(k, 0)
+        return total
+
+    def get_parse_usage_stats(self):
+        """Return parse-step token usage (parse is not counted as an api_call)."""
+        return dict(self._parse_usage)
+
+    def reset_usage_stats(self):
+        """Reset all usage counters – call before each forward pass."""
+        for proc in self.processor_graph.nodes:
+            proc._usage_stats = {
+                'prompt_tokens': 0,
+                'completion_tokens': 0,
+                'total_tokens': 0,
+                'api_calls': 0,
+            }
+        self._parse_usage = {
+            'prompt_tokens': 0,
+            'completion_tokens': 0,
+            'total_tokens': 0,
+        }
+
+    # ------------------------------------------------------------------
+    # link_form: only non-winner processors answer the winner's questions;
+    # their answers are cached straight into the winner's fuse_history so
+    # the fuse step does not have to re-ask.
+    # ------------------------------------------------------------------
+
+    @logging_func_with_count
+    def link_form(
+        self, chunks: List[Chunk], winning_chunk: Chunk, **input_kwargs: Any
+    ) -> None:
+        form_t = self.LINK_FORM_THRESHOLD
+
+        additional_questions = winning_chunk.additional_questions or []
+        valid_questions = [q for q in additional_questions if q]
+        if not valid_questions:
+            return
+
+        combined_query = 'Please answer the following questions:\n'
+        for i, q in enumerate(valid_questions, 1):
+            combined_query += f'{i}. {q}\n'
+
+        proc_map = {p.name: p for p in self.processor_graph.nodes}
+        w_name = winning_chunk.processor_name
+        ask_self = self.LINK_FORM_ASK_SELF
+        procs_to_ask = (
+            list(self.processor_graph.nodes)
+            if ask_self
+            else [p for p in self.processor_graph.nodes if p.name != w_name]
+        )
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(
+                    lambda p: p.ask(
+                        query=combined_query, phase='link_form', **input_kwargs
+                    ),
+                    proc,
+                )
+                for proc in procs_to_ask
+            ]
+            question_chunks = [
+                f.result() for f in concurrent.futures.as_completed(futures)
+            ]
+        question_chunks = [c for c in question_chunks if c is not None]
+
+        if self.detailed_log is not None:
+            current_iteration = self.detailed_log['current_iteration']
+            for chunk in question_chunks:
+                link_info = {
+                    'processor_name': chunk.processor_name,
+                    'query': chunk.executor_content or combined_query,
+                    'answer': chunk.gist,
+                    'relevance': chunk.relevance,
+                }
+                current_iteration['link_form_phase'].append(link_info)
+
+        for chunk in question_chunks:
+            c_name = chunk.processor_name
+            already_linked = c_name in self.processor_graph.get_neighbor_names(
+                w_name
+            )
+            passes_threshold = chunk.relevance >= form_t
+
+            if passes_threshold:
+                self.processor_graph.add_link(
+                    processor1_name=w_name,
+                    processor2_name=c_name,
+                    allow_self=ask_self,
+                )
+                if not already_linked:
+                    logger.info(
+                        f'Adding link (relevance={chunk.relevance:.3f} >= {form_t}) '
+                        f'between {w_name} and {c_name}'
+                    )
+                    self._iter_links_added += 1
+                    self._total_links_added += 1
+
+            # Cache the non-winner's answer into winner.fuse_history whenever
+            # an edge exists between them — either newly formed this iter
+            # (passes_threshold) or from a previous iter (already_linked).
+            # This matches 09446d4 fuse semantics: fuse would fire over any
+            # existing edge regardless of current relevance.
+            if (passes_threshold or already_linked) and chunk.gist:
+                proc_map[w_name].add_fuse_history(
+                    combined_query, chunk.gist, c_name
+                )
+
+                if self.detailed_log is not None:
+                    current_iteration['fuse_phase'].append(
+                        {
+                            'from_processor': w_name,
+                            'to_processor': c_name,
+                            'query': combined_query,
+                            'answer': chunk.gist,
+                            'source': 'link_form_cache',
+                            'relevance': chunk.relevance,
+                            'edge_pre_existing': already_linked,
+                        }
+                    )
+
+    # ------------------------------------------------------------------
+    # fuse_processor: only the winning processor answers the linked
+    # non-winners' questions. (link_form already cached the reverse
+    # direction.)
+    # ------------------------------------------------------------------
+
+    @logging_func_with_count
+    def fuse_processor(
+        self,
+        chunks: List[Chunk],
+        query: str,
+        winning_chunk: Chunk = None,
+        **input_kwargs: Any,
+    ) -> None:
+        if winning_chunk is None:
+            return
+
+        proc_map = {p.name: p for p in self.processor_graph.nodes}
+        w_name = winning_chunk.processor_name
+
+        # Iterate non-winner chunks; for each, ask ALL of its linked neighbors
+        # (winner AND other linked non-winners) to answer its follow-up
+        # questions. This restores the non-winner ↔ non-winner information flow
+        # that existed in the original CTM and was missing from the winner-only
+        # optimization. Winner's own follow-ups are already answered via
+        # link_form caching, so we skip chunk = winner.
+        for chunk in chunks:
+            c_name = chunk.processor_name
+            if c_name == w_name:
+                continue
+
+            neighbors = self.processor_graph.get_neighbor_names(c_name)
+            if not neighbors:
+                continue
+
+            additional_questions = chunk.additional_questions or []
+            valid_questions = [q for q in additional_questions if q]
+            if not valid_questions:
+                continue
+
+            combined_query = 'Please answer the following questions:\n'
+            for i, q in enumerate(valid_questions, 1):
+                combined_query += f'{i}. {q}\n'
+
+            for nbr in neighbors:
+                if nbr == c_name:
+                    continue
+                nbr_proc = proc_map.get(nbr)
+                if nbr_proc is None:
+                    continue
+
+                answer_chunk = nbr_proc.ask(
+                    query=combined_query, phase='fuse', **input_kwargs
+                )
+                if answer_chunk is None:
+                    continue
+
+                proc_map[c_name].add_fuse_history(
+                    combined_query, answer_chunk.gist, nbr
+                )
+
+                if self.detailed_log is not None:
+                    current_iteration = self.detailed_log['current_iteration']
+                    current_iteration['fuse_phase'].append(
+                        {
+                            'from_processor': c_name,
+                            'to_processor': nbr,
+                            'query': answer_chunk.executor_content or combined_query,
+                            'answer': answer_chunk.gist,
+                        }
+                    )
+
+    # ------------------------------------------------------------------
+    # go_down: broadcast + link_form
     # ------------------------------------------------------------------
 
     @logging_func_with_count
     def go_down(
-        self, winning_chunk: Chunk, chunks: List[Chunk], **input_kwargs
+        self, winning_chunk: Chunk, chunks: List[Chunk], **input_kwargs: Any
     ) -> None:
         logger.info(f'Going down with winning chunk: {winning_chunk.processor_name}')
         self.downtree_broadcast(winning_chunk)
@@ -125,8 +357,8 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
         video_path: Optional[str] = None,
         api_manager: Any = None,
         instance_id: Optional[str] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Tuple[str, float, str]:
         """Run the iterative CTM loop.
 
@@ -157,10 +389,16 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
         }
 
         self.iteration_history = []
+        self._total_links_added = 0
+        self.reset_usage_stats()
         answer = ''
         weight_score = 0.0
 
-        for i in range(self.config.max_iter_num):
+        max_iters = self.config.max_iter_num
+
+        for i in range(max_iters):
+            self._iter_links_added = 0
+
             self.detailed_log['current_iteration'] = {
                 'iteration': i + 1,
                 'initial_phase': [],
@@ -183,6 +421,52 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
                 winning_chunk.weight
             )
 
+            is_final_iter = (
+                i == max_iters - 1 or weight_score >= self.config.output_threshold
+            )
+
+            if is_final_iter:
+                iteration_info = {
+                    'iteration': i + 1,
+                    'winning_processor': winning_chunk.processor_name,
+                    'winning_weight': winning_chunk.weight,
+                    'winning_answer': winning_chunk.gist,
+                    'all_chunks': [
+                        {
+                            'processor_name': c.processor_name,
+                            'weight': c.weight,
+                            'relevance': c.relevance,
+                            'confidence': c.confidence,
+                            'surprise': c.surprise,
+                        }
+                        for c in chunks
+                    ],
+                    'links_added': self._iter_links_added,
+                }
+                self.iteration_history.append(iteration_info)
+
+                self.detailed_log['iterations'].append(
+                    self.detailed_log['current_iteration']
+                )
+                self.detailed_log['current_iteration'] = None
+
+                parsed_answer = self.parse_answer(answer=answer, query=query)
+
+                self.detailed_log['final_answer'] = answer
+                self.detailed_log['final_weight'] = weight_score
+                self.detailed_log['parsed_answer'] = parsed_answer
+                self._save_detailed_log()
+
+                return answer, weight_score, parsed_answer
+
+            # Downtree + link_form
+            self.go_down(winning_chunk, chunks, **input_params)
+
+            # Fusion
+            self.fuse_processor(
+                chunks, query, winning_chunk=winning_chunk, **input_params
+            )
+
             iteration_info = {
                 'iteration': i + 1,
                 'winning_processor': winning_chunk.processor_name,
@@ -198,34 +482,15 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
                     }
                     for c in chunks
                 ],
+                'links_added': self._iter_links_added,
             }
             self.iteration_history.append(iteration_info)
-
-            if (
-                i == self.config.max_iter_num - 1
-                or weight_score >= self.config.output_threshold
-            ):
-                self.detailed_log['iterations'].append(
-                    self.detailed_log['current_iteration']
-                )
-                self.detailed_log['current_iteration'] = None
-
-                parsed_answer = self.parse_answer(answer=answer, query=query)
-
-                self.detailed_log['final_answer'] = answer
-                self.detailed_log['final_weight'] = weight_score
-                self.detailed_log['parsed_answer'] = parsed_answer
-                self._save_detailed_log()
-
-                return answer, weight_score, parsed_answer
-
-            self.go_down(winning_chunk, chunks, **input_params)
-            self.fuse_processor(chunks, query, **input_params)
 
             self.detailed_log['iterations'].append(
                 self.detailed_log['current_iteration']
             )
 
+        # Fallback (not normally reached)
         parsed_answer = self.parse_answer(answer=answer, query=query)
 
         self.detailed_log['final_answer'] = answer
@@ -243,7 +508,7 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
         if self.detailed_log is None or self.detailed_log.get('instance_id') is None:
             return
 
-        output_dir = 'detailed_info'
+        output_dir = self.detailed_log_dir or 'detailed_info'
         os.makedirs(output_dir, exist_ok=True)
 
         log_to_save = {

--- a/ctm_ai/ctms/ctm_ablation.py
+++ b/ctm_ai/ctms/ctm_ablation.py
@@ -1,14 +1,17 @@
 """Ablation-enabled CTM.
 
-Adds optional overrides on top of the standard ConsciousTuringMachine:
-  - output_threshold_override: override config.output_threshold
-  - link_form_threshold: override hardcoded 0.8 link-add threshold
-  - enable_* flags: selectively disable CTM phases for component ablation
-  - detailed_log_dir: where per-instance trajectories are saved
+Thin subclass of :class:`ConsciousTuringMachine` that exposes component and
+threshold knobs for ablation studies. Core CTM logic (link_form / fuse /
+usage tracking / detailed_log_dir) lives in the base class.
+
+Overrides:
+  - output_threshold_override, max_iter_override    configurable limits
+  - link_form_threshold                             override LINK_FORM_THRESHOLD
+  - enable_fusion / enable_uptree_competition /
+    enable_downtree_broadcast / enable_link_form /
+    enable_iteration                                selectively disable phases
 """
 
-import json
-import os
 from typing import Any, List, Optional, Tuple
 
 import numpy as np
@@ -22,7 +25,7 @@ from .ctm import ConsciousTuringMachine
 class AblationCTM(ConsciousTuringMachine):
     """CTM with ablation knobs.
 
-    All overrides are optional; when None we fall back to config / base defaults.
+    All overrides are optional; when ``None`` the base config / defaults apply.
     """
 
     def __init__(
@@ -37,6 +40,7 @@ class AblationCTM(ConsciousTuringMachine):
         enable_link_form: bool = True,
         enable_iteration: bool = True,
         link_form_threshold: Optional[float] = None,
+        link_form_ask_self: bool = False,
         output_threshold_override: Optional[float] = None,
         max_iter_override: Optional[int] = None,
         detailed_log_dir: Optional[str] = None,
@@ -45,6 +49,7 @@ class AblationCTM(ConsciousTuringMachine):
             ctm_name=ctm_name,
             api_manager=api_manager,
             num_additional_questions=num_additional_questions,
+            detailed_log_dir=detailed_log_dir,
         )
         self.enable_fusion = enable_fusion
         self.enable_uptree_competition = enable_uptree_competition
@@ -52,194 +57,45 @@ class AblationCTM(ConsciousTuringMachine):
         self.enable_link_form = enable_link_form
         self.enable_iteration = enable_iteration
         self.link_form_threshold = link_form_threshold
+        self.link_form_ask_self = link_form_ask_self
         self.output_threshold_override = output_threshold_override
         self.max_iter_override = max_iter_override
-        self.detailed_log_dir = detailed_log_dir
+
+        # Instance-level override — base class reads LINK_FORM_ASK_SELF via
+        # self lookup, so setting as instance attr shadows the class attr.
+        self.LINK_FORM_ASK_SELF = link_form_ask_self
 
         if output_threshold_override is not None:
             self.config.output_threshold = output_threshold_override
         if max_iter_override is not None:
             self.config.max_iter_num = max_iter_override
 
-        self._iter_links_added = 0
-        self._total_links_added = 0
-        self._api_calls = 0
-        self._parse_usage = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0, 'api_calls': 0}
-
     # ------------------------------------------------------------------
-    # API call & token tracking
+    # Override link_form only to pick up a custom threshold.
     # ------------------------------------------------------------------
 
-    def get_usage_stats(self):
-        """Aggregate usage stats from all processors (excluding parse)."""
-        total = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0, 'api_calls': 0}
-        for proc in self.processor_graph.nodes:
-            for k in total:
-                total[k] += proc._usage_stats.get(k, 0)
-        return total
-
-    def get_parse_usage_stats(self):
-        """Return parse-only usage stats."""
-        return dict(self._parse_usage)
-
-    def reset_usage_stats(self):
-        """Reset all usage counters (call before each forward pass)."""
-        for proc in self.processor_graph.nodes:
-            proc._usage_stats = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0, 'api_calls': 0}
-        self._parse_usage = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0, 'api_calls': 0}
-
-    # ------------------------------------------------------------------
-    # Link formation with configurable thresholds
-    # ------------------------------------------------------------------
+    @property
+    def _active_link_form_threshold(self) -> float:
+        return (
+            self.link_form_threshold
+            if self.link_form_threshold is not None
+            else self.LINK_FORM_THRESHOLD
+        )
 
     @logging_func_with_count
     def link_form(
         self, chunks: List[Chunk], winning_chunk: Chunk, **input_kwargs: Any
     ) -> None:
-        """Form links and cache answers for fuse.
-
-        Only asks non-winner processors (winner's own answer is useless
-        for cross-modal exchange). If relevance >= threshold, add link
-        AND cache the answer into the winner's fuse_history directly.
-        Edges only grow (no link break).
-        """
-        import concurrent.futures
-
-        form_t = (
-            self.link_form_threshold if self.link_form_threshold is not None else 0.8
-        )
-
-        additional_questions = winning_chunk.additional_questions or []
-        valid_questions = [q for q in additional_questions if q]
-        if not valid_questions:
-            return
-
-        combined_query = 'Please answer the following questions:\n'
-        for i, q in enumerate(valid_questions, 1):
-            combined_query += f'{i}. {q}\n'
-
-        # Only ask non-winner processors (saves 1 API call per iteration)
-        proc_map = {p.name: p for p in self.processor_graph.nodes}
-        w_name = winning_chunk.processor_name
-        non_winner_procs = [p for p in self.processor_graph.nodes if p.name != w_name]
-
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(
-                    lambda p: p.ask(query=combined_query, phase='link_form', **input_kwargs),
-                    proc,
-                )
-                for proc in non_winner_procs
-            ]
-            question_chunks = [
-                f.result() for f in concurrent.futures.as_completed(futures)
-            ]
-        question_chunks = [c for c in question_chunks if c is not None]
-
-        if self.detailed_log is not None:
-            current_iteration = self.detailed_log['current_iteration']
-            for chunk in question_chunks:
-                link_info = {
-                    'processor_name': chunk.processor_name,
-                    'query': chunk.executor_content or combined_query,
-                    'answer': chunk.gist,
-                    'relevance': chunk.relevance,
-                }
-                current_iteration['link_form_phase'].append(link_info)
-
-        for chunk in question_chunks:
-            c_name = chunk.processor_name
-
-            if chunk.relevance >= form_t:
-                already_linked = c_name in self.processor_graph.get_neighbor_names(w_name)
-                self.processor_graph.add_link(
-                    processor1_name=w_name,
-                    processor2_name=c_name,
-                )
-                if not already_linked:
-                    logger.info(
-                        f'[ABLATION] Adding link (relevance={chunk.relevance:.3f} >= {form_t}) '
-                        f'between {w_name} and {c_name}'
-                    )
-                    self._iter_links_added += 1
-                    self._total_links_added += 1
-
-                # Cache: add this processor's answer to winning processor's
-                # fuse_history directly — no need to re-ask in fuse.
-                if chunk.gist:
-                    proc_map[w_name].add_fuse_history(
-                        combined_query, chunk.gist, c_name
-                    )
-
-                    if self.detailed_log is not None:
-                        current_iteration['fuse_phase'].append({
-                            'from_processor': w_name,
-                            'to_processor': c_name,
-                            'query': combined_query,
-                            'answer': chunk.gist,
-                            'source': 'link_form_cache',
-                        })
+        # Temporarily shadow LINK_FORM_THRESHOLD for this call.
+        original = self.LINK_FORM_THRESHOLD
+        self.LINK_FORM_THRESHOLD = self._active_link_form_threshold
+        try:
+            super().link_form(chunks, winning_chunk, **input_kwargs)
+        finally:
+            self.LINK_FORM_THRESHOLD = original
 
     # ------------------------------------------------------------------
-    # Fuse: only winning processor answers other processors' questions
-    # ------------------------------------------------------------------
-
-    @logging_func_with_count
-    def fuse_processor(
-        self, chunks: List[Chunk], query: str, winning_chunk: Chunk = None, **input_kwargs
-    ) -> None:
-        """Efficient fuse: only the winning processor answers others' questions.
-
-        link_form already cached non-winner → winner answers.
-        Here we do the reverse: winner answers each linked non-winner's questions.
-        """
-        if winning_chunk is None:
-            # Fallback to base implementation if no winner info
-            return super().fuse_processor(chunks, query, **input_kwargs)
-
-        proc_map = {p.name: p for p in self.processor_graph.nodes}
-        w_name = winning_chunk.processor_name
-        winner_proc = proc_map.get(w_name)
-        if winner_proc is None:
-            return
-
-        for chunk in chunks:
-            if chunk.processor_name == w_name:
-                continue  # skip winner itself
-
-            # Only fuse with linked processors
-            if chunk.processor_name not in self.processor_graph.get_neighbor_names(w_name):
-                continue
-
-            additional_questions = chunk.additional_questions or []
-            valid_questions = [q for q in additional_questions if q]
-            if not valid_questions:
-                continue
-
-            combined_query = 'Please answer the following questions:\n'
-            for i, q in enumerate(valid_questions, 1):
-                combined_query += f'{i}. {q}\n'
-
-            # Winner answers this processor's questions
-            answer_chunk = winner_proc.ask(
-                query=combined_query, phase='fuse', **input_kwargs
-            )
-            if answer_chunk is not None:
-                proc_map[chunk.processor_name].add_fuse_history(
-                    combined_query, answer_chunk.gist, w_name
-                )
-
-                if self.detailed_log is not None:
-                    current_iteration = self.detailed_log['current_iteration']
-                    current_iteration['fuse_phase'].append({
-                        'from_processor': chunk.processor_name,
-                        'to_processor': w_name,
-                        'query': answer_chunk.executor_content or combined_query,
-                        'answer': answer_chunk.gist,
-                    })
-
-    # ------------------------------------------------------------------
-    # Go down (broadcast + link_form) with ablation flags
+    # go_down: honor enable_downtree_broadcast / enable_link_form flags.
     # ------------------------------------------------------------------
 
     @logging_func_with_count
@@ -256,7 +112,8 @@ class AblationCTM(ConsciousTuringMachine):
             logger.info('[ABLATION] Skipping link_form')
 
     # ------------------------------------------------------------------
-    # Forward with ablation flags (mirrors ConsciousTuringMachine.forward)
+    # Forward: honor enable_iteration / enable_uptree_competition /
+    # enable_fusion. All other behavior delegated to the base.
     # ------------------------------------------------------------------
 
     def forward(
@@ -309,7 +166,6 @@ class AblationCTM(ConsciousTuringMachine):
 
         self.iteration_history = []
         self._total_links_added = 0
-        self._api_calls = 0
         self.reset_usage_stats()
         answer = ''
         weight_score = 0.0
@@ -333,7 +189,6 @@ class AblationCTM(ConsciousTuringMachine):
             if self.enable_uptree_competition:
                 winning_chunk = self.uptree_competition(chunks)
             else:
-                # Fallback: pick highest-weight chunk deterministically
                 winning_chunk = max(chunks, key=lambda c: c.weight)
                 logger.info('[ABLATION] Skipping uptree_competition (argmax fallback)')
 
@@ -348,12 +203,10 @@ class AblationCTM(ConsciousTuringMachine):
             )
 
             is_final_iter = (
-                i == max_iters - 1
-                or weight_score >= self.config.output_threshold
+                i == max_iters - 1 or weight_score >= self.config.output_threshold
             )
 
             if is_final_iter:
-                # Build iteration_info BEFORE returning (no link_form runs on last iter)
                 iteration_info = {
                     'iteration': i + 1,
                     'winning_processor': winning_chunk.processor_name,
@@ -387,16 +240,15 @@ class AblationCTM(ConsciousTuringMachine):
 
                 return answer, weight_score, parsed_answer
 
-            # --- Downtree + link_form (ablation-aware) ---
             self.go_down(winning_chunk, chunks, **input_params)
 
-            # --- Fusion (ablation-aware) ---
             if self.enable_fusion:
-                self.fuse_processor(chunks, query, winning_chunk=winning_chunk, **input_params)
+                self.fuse_processor(
+                    chunks, query, winning_chunk=winning_chunk, **input_params
+                )
             else:
                 logger.info('[ABLATION] Skipping fusion')
 
-            # Record iteration AFTER link_form so link counts are correct
             iteration_info = {
                 'iteration': i + 1,
                 'winning_processor': winning_chunk.processor_name,
@@ -420,7 +272,6 @@ class AblationCTM(ConsciousTuringMachine):
                 self.detailed_log['current_iteration']
             )
 
-        # Fallback (should not normally reach here)
         parsed_answer = self.parse_answer(answer=answer, query=query)
 
         self.detailed_log['final_answer'] = answer
@@ -429,26 +280,3 @@ class AblationCTM(ConsciousTuringMachine):
         self._save_detailed_log()
 
         return answer, weight_score, parsed_answer
-
-    # ------------------------------------------------------------------
-    # Save trajectories to a custom directory
-    # ------------------------------------------------------------------
-
-    def _save_detailed_log(self) -> None:
-        if self.detailed_log is None or self.detailed_log.get('instance_id') is None:
-            return
-
-        output_dir = self.detailed_log_dir or 'detailed_info'
-        os.makedirs(output_dir, exist_ok=True)
-
-        log_to_save = {
-            k: v for k, v in self.detailed_log.items() if k != 'current_iteration'
-        }
-
-        instance_id = self.detailed_log['instance_id']
-        output_path = os.path.join(output_dir, f'{instance_id}.json')
-
-        with open(output_path, 'w', encoding='utf-8') as f:
-            json.dump(log_to_save, f, indent=2, ensure_ascii=False)
-
-        logger.info(f'Detailed log saved to {output_path}')

--- a/ctm_ai/ctms/ctm_base.py
+++ b/ctm_ai/ctms/ctm_base.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import time
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Tuple
 
@@ -181,26 +182,47 @@ class BaseConsciousTuringMachine(ABC):
         if parse_extra_body:
             completion_kwargs['extra_body'] = parse_extra_body
 
-        try:
-            parse_temp = getattr(self.config, 'parse_temperature', 0.3)
-            response = completion(
-                **completion_kwargs,
-                messages=[{'role': 'user', 'content': parse_prompt}],
-                max_tokens=4096,
-                temperature=parse_temp,
-            )
+        parse_temp = getattr(self.config, 'parse_temperature', 0.3)
 
-            parsed_answer = response.choices[0].message.content.strip()
-            if hasattr(self, '_parse_usage') and hasattr(response, 'usage') and response.usage:
-                self._parse_usage['prompt_tokens'] += getattr(response.usage, 'prompt_tokens', 0) or 0
-                self._parse_usage['completion_tokens'] += getattr(response.usage, 'completion_tokens', 0) or 0
-                self._parse_usage['total_tokens'] += getattr(response.usage, 'total_tokens', 0) or 0
-                self._parse_usage['api_calls'] += 1
-            return parsed_answer
+        # Retry with exponential backoff on transient failures (503 / rate limit
+        # / timeout). Matches the 5-retry pattern used by ask_executor's
+        # @message_exponential_backoff decorator. Without this, a single transient
+        # error on the parse step silently returns the raw CTM analysis as the
+        # "parsed" answer, breaking downstream Yes/No classification.
+        retries = 5
+        base_wait = 1
+        last_exc: Optional[Exception] = None
+        for attempt in range(retries):
+            try:
+                response = completion(
+                    **completion_kwargs,
+                    messages=[{'role': 'user', 'content': parse_prompt}],
+                    max_tokens=4096,
+                    temperature=parse_temp,
+                )
+                parsed_answer = response.choices[0].message.content.strip()
+                # Parse step tracks tokens for cost calculation but is NOT
+                # counted as an api_call (it's a post-processing formatting step,
+                # not part of the CTM reasoning loop).
+                if hasattr(self, '_parse_usage') and hasattr(response, 'usage') and response.usage:
+                    self._parse_usage['prompt_tokens'] += getattr(response.usage, 'prompt_tokens', 0) or 0
+                    self._parse_usage['completion_tokens'] += getattr(response.usage, 'completion_tokens', 0) or 0
+                    self._parse_usage['total_tokens'] += getattr(response.usage, 'total_tokens', 0) or 0
+                return parsed_answer
+            except Exception as e:
+                last_exc = e
+                wait_time = base_wait * (2 ** attempt)
+                logger.warning(
+                    f'parse_answer attempt {attempt + 1}/{retries} failed: {e}. '
+                    f'Retrying in {wait_time}s...'
+                )
+                time.sleep(wait_time)
 
-        except Exception as e:
-            logger.warning(f'Failed to parse answer with litellm: {e}')
-            return answer
+        logger.warning(
+            f'parse_answer exhausted {retries} retries; returning raw answer. '
+            f'Last error: {last_exc}'
+        )
+        return answer
 
     @logging_func_with_count
     def uptree_competition(self, chunks: List[Chunk]) -> Chunk:

--- a/ctm_ai/graphs/processor_graph.py
+++ b/ctm_ai/graphs/processor_graph.py
@@ -36,7 +36,14 @@ class ProcessorGraph:
                 if processor_name in neighbors:
                     neighbors.remove(processor_name)
 
-    def add_link(self, processor1_name: str, processor2_name: str) -> None:
+    def add_link(
+        self,
+        processor1_name: str,
+        processor2_name: str,
+        allow_self: bool = False,
+    ) -> None:
+        if processor1_name == processor2_name and not allow_self:
+            return
         if (
             processor1_name in self.adjacency_list
             and processor2_name in self.adjacency_list

--- a/exp_affective/run_ctm.py
+++ b/exp_affective/run_ctm.py
@@ -39,6 +39,7 @@ def run_instance(
     dataset_name,
     ctm_name,
     output_file='ctm_results.jsonl',
+    detailed_log_dir=None,
 ):
     try:
         print(f'[{test_file}] Starting processing...')
@@ -46,7 +47,7 @@ def run_instance(
         config = get_dataset_config(dataset_name)
         sample = dataset[test_file]
 
-        ctm = ConsciousTuringMachine(ctm_name)
+        ctm = ConsciousTuringMachine(ctm_name, detailed_log_dir=detailed_log_dir)
         target_sentence = config.get_text_field(sample)
         query = config.get_task_query()
 
@@ -119,12 +120,20 @@ def run_instance(
 
 
 def run_parallel(
-    dataset, dataset_name, ctm_name, max_workers=4, output_file='ctm_results.jsonl'
+    dataset,
+    dataset_name,
+    ctm_name,
+    max_workers=4,
+    output_file='ctm_results.jsonl',
+    detailed_log_dir=None,
 ):
     test_list = list(dataset.keys())
     print(f'Total test samples: {len(test_list)}')
     print(f'Using {max_workers} workers')
     print(f'Output file: {output_file}')
+    if detailed_log_dir:
+        print(f'Detailed log dir: {detailed_log_dir}')
+        os.makedirs(detailed_log_dir, exist_ok=True)
     print('=' * 50)
 
     with open(output_file, 'w', encoding='utf-8'):
@@ -136,7 +145,13 @@ def run_parallel(
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_test = {
             executor.submit(
-                run_instance, test_file, dataset, dataset_name, ctm_name, output_file
+                run_instance,
+                test_file,
+                dataset,
+                dataset_name,
+                ctm_name,
+                output_file,
+                detailed_log_dir,
             ): test_file
             for test_file in test_list
         }
@@ -191,6 +206,12 @@ if __name__ == '__main__':
         default=8,
         help='Number of parallel workers (default: 16)',
     )
+    parser.add_argument(
+        '--detailed_log_dir',
+        type=str,
+        default=None,
+        help='Directory for per-instance trajectory JSON files (default: detailed_info/)',
+    )
     args = parser.parse_args()
 
     # Get dataset configuration
@@ -221,4 +242,5 @@ if __name__ == '__main__':
         args.ctm_name,
         max_workers=args.max_workers,
         output_file=output_file,
+        detailed_log_dir=args.detailed_log_dir,
     )

--- a/exp_affective/run_ctm_ablation.py
+++ b/exp_affective/run_ctm_ablation.py
@@ -166,7 +166,7 @@ def run_instance(
         print(
             f'[{test_file}] Done in {elapsed:.1f}s | '
             f'iters={num_iterations} | links_added={total_links_added} | '
-            f'api_calls={ctm_usage["api_calls"]}+1parse | '
+            f'api_calls={ctm_usage["api_calls"]} | '
             f'tokens={ctm_usage["total_tokens"]}+{parse_usage["total_tokens"]}parse | '
             f'cost=${total_cost:.4f} | '
             f"parsed={parsed_answer[:50]}"
@@ -187,7 +187,6 @@ def run_instance(
                 'ctm_prompt_tokens': ctm_usage['prompt_tokens'],
                 'ctm_completion_tokens': ctm_usage['completion_tokens'],
                 'ctm_total_tokens': ctm_usage['total_tokens'],
-                'parse_api_calls': parse_usage['api_calls'],
                 'parse_prompt_tokens': parse_usage['prompt_tokens'],
                 'parse_completion_tokens': parse_usage['completion_tokens'],
                 'parse_total_tokens': parse_usage['total_tokens'],
@@ -264,6 +263,8 @@ def run_ablation(
         ablation_tag = f'{ablation_tag}_ot{tk["output_threshold_override"]}'
     if tk.get('max_iter_override') is not None:
         ablation_tag = f'{ablation_tag}_iter{tk["max_iter_override"]}'
+    if tk.get('link_form_ask_self'):
+        ablation_tag = f'{ablation_tag}_askself'
 
     if modality:
         ablation_tag = f'{ablation_tag}_only_{modality}'
@@ -393,6 +394,11 @@ if __name__ == '__main__':
         help='Override max_iter_num in config.')
     parser.add_argument('--run_link_thresholds', action='store_true')
     parser.add_argument('--run_output_thresholds', action='store_true')
+    parser.add_argument(
+        '--link_form_ask_self',
+        action='store_true',
+        help='Include winner in link_form (winner answers its own follow-up questions and may link to itself).',
+    )
     args = parser.parse_args()
 
     config = get_dataset_config(args.dataset_name)
@@ -416,6 +422,8 @@ if __name__ == '__main__':
         threshold_kwargs['output_threshold_override'] = args.output_threshold
     if args.max_iter is not None:
         threshold_kwargs['max_iter_override'] = args.max_iter
+    if args.link_form_ask_self:
+        threshold_kwargs['link_form_ask_self'] = True
 
     LINK_THRESHOLD_PRESETS = [
         {'link_form_threshold': 0.3},


### PR DESCRIPTION
Core refactor:
- Promote AblationCTM's efficient link_form (winner skip + cache) and fuse (non-winner chunk → all linked neighbors) into ConsciousTuringMachine
- AblationCTM slimmed to a thin subclass exposing ablation flags and threshold overrides only
- Fuse restored to include non-winner <-> non-winner exchange when a triangle edge exists (was lost in the winner-only simplification)
- link_form cache fires on any pre-existing edge, not only relevance >= 0.8 (matches 09446d4's fuse-over-existing-edge semantics)

Bug fixes:
- processor_graph.add_link: reject self-loops by default (allow_self param for explicit opt-in via ablation)
- ctm_base.parse_answer: add 5-retry exponential backoff. Previously one 503 on the parse step silently returned the raw CTM analysis as parsed_answer (~1.8% rate on mustard under typical Gemini load)
- parse step tracks tokens in _parse_usage but is NOT counted as an api_call (it is post-processing, not part of the CTM reasoning loop)

New knobs:
- run_ctm.py: --detailed_log_dir for custom trajectory folder
- run_ctm_ablation.py: --link_form_ask_self for winner-self-answer ablation
- ConsciousTuringMachine.LINK_FORM_THRESHOLD / LINK_FORM_ASK_SELF class attributes for subclass override

Validated on mustard (356 samples, gemini-2.5-flash-lite):
- New code: 69.94% acc / 69.86% F1
- Original 09446d4: 71.47% acc / 70.55% F1
- delta = -1.53% acc, well within run-to-run std (+/- 3.77%)
- pastinj off (n=2) 70.37 +/- 3.77% confirms equivalence

<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [ ] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
