### PR TITLE
perf(ctm): parallelize fuse_processor ask calls

### DIFF
--- a/ctm_ai/ctms/ctm.py
+++ b/ctm_ai/ctms/ctm.py
@@ -282,6 +282,11 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
         # that existed in the original CTM and was missing from the winner-only
         # optimization. Winner's own follow-ups are already answered via
         # link_form caching, so we skip chunk = winner.
+
+        # Pass 1: materialize the (c_name, nbr, nbr_proc, combined_query) task
+        # list in the same order the original nested for-loops produced, so
+        # downstream fuse_history / detailed_log append order is unchanged.
+        tasks = []
         for chunk in chunks:
             c_name = chunk.processor_name
             if c_name == w_name:
@@ -306,27 +311,49 @@ class ConsciousTuringMachine(BaseConsciousTuringMachine):
                 nbr_proc = proc_map.get(nbr)
                 if nbr_proc is None:
                     continue
+                tasks.append((c_name, nbr, nbr_proc, combined_query))
 
-                answer_chunk = nbr_proc.ask(
-                    query=combined_query, phase='fuse', **input_kwargs
+        if not tasks:
+            return
+
+        # Pass 2: dispatch all ask(phase='fuse') calls concurrently. Results
+        # are collected in submission order (via ordered futures.result(),
+        # NOT as_completed) so the original ordering is preserved.
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(
+                    nbr_proc.ask,
+                    query=combined_query,
+                    phase='fuse',
+                    **input_kwargs,
                 )
-                if answer_chunk is None:
-                    continue
+                for (_c, _n, nbr_proc, combined_query) in tasks
+            ]
+            answer_chunks = [f.result() for f in futures]
 
-                proc_map[c_name].add_fuse_history(
-                    combined_query, answer_chunk.gist, nbr
+        # Pass 3: apply side effects serially in the original order so that
+        # fuse_history / detailed_log entries are identical to the sequential
+        # implementation.
+        for (c_name, nbr, _nbr_proc, combined_query), answer_chunk in zip(
+            tasks, answer_chunks
+        ):
+            if answer_chunk is None:
+                continue
+
+            proc_map[c_name].add_fuse_history(
+                combined_query, answer_chunk.gist, nbr
+            )
+
+            if self.detailed_log is not None:
+                current_iteration = self.detailed_log['current_iteration']
+                current_iteration['fuse_phase'].append(
+                    {
+                        'from_processor': c_name,
+                        'to_processor': nbr,
+                        'query': answer_chunk.executor_content or combined_query,
+                        'answer': answer_chunk.gist,
+                    }
                 )
-
-                if self.detailed_log is not None:
-                    current_iteration = self.detailed_log['current_iteration']
-                    current_iteration['fuse_phase'].append(
-                        {
-                            'from_processor': c_name,
-                            'to_processor': nbr,
-                            'query': answer_chunk.executor_content or combined_query,
-                            'answer': answer_chunk.gist,
-                        }
-                    )
 
     # ------------------------------------------------------------------
     # go_down: broadcast + link_form

--- a/ctm_ai/ctms/ctm_base.py
+++ b/ctm_ai/ctms/ctm_base.py
@@ -290,6 +290,9 @@ class BaseConsciousTuringMachine(ABC):
     def fuse_processor(self, chunks: List[Chunk], query: str, **input_kwargs) -> None:
         proc_map = {p.name: p for p in self.processor_graph.nodes}
 
+        # Pass 1: collect tasks in the original nested-for order so that the
+        # resulting fuse_history / detailed_log append order is unchanged.
+        tasks = []
         for chunk in chunks:
             additional_questions = chunk.additional_questions or []
             valid_questions = [q for q in additional_questions if q]
@@ -305,28 +308,50 @@ class BaseConsciousTuringMachine(ABC):
             for nbr in self.processor_graph.get_neighbor_names(chunk.processor_name):
                 if nbr == chunk.processor_name:
                     continue
+                nbr_proc = proc_map.get(nbr)
+                if nbr_proc is None:
+                    continue
+                tasks.append(
+                    (chunk.processor_name, nbr, nbr_proc, combined_query)
+                )
 
-                # Use fuse phase - ask all questions at once, only need response
-                answer_chunk = proc_map[nbr].ask(
+        if not tasks:
+            return
+
+        # Pass 2: dispatch ask(phase='fuse') calls in parallel, preserving
+        # submission order via ordered futures.result().
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(
+                    nbr_proc.ask,
                     query=combined_query,
                     phase='fuse',
                     **input_kwargs,
                 )
-                if answer_chunk is not None:
-                    proc_map[chunk.processor_name].add_fuse_history(
-                        combined_query, answer_chunk.gist, nbr
-                    )
+                for (_c, _n, nbr_proc, combined_query) in tasks
+            ]
+            answer_chunks = [f.result() for f in futures]
 
-                    # Log fuse phase details
-                    if self.detailed_log is not None:
-                        current_iteration = self.detailed_log['current_iteration']
-                        fuse_info = {
-                            'from_processor': chunk.processor_name,
-                            'to_processor': nbr,
-                            'query': answer_chunk.executor_content or combined_query,
-                            'answer': answer_chunk.gist,
-                        }
-                        current_iteration['fuse_phase'].append(fuse_info)
+        # Pass 3: apply side effects serially in the original order.
+        for (c_name, nbr, _nbr_proc, combined_query), answer_chunk in zip(
+            tasks, answer_chunks
+        ):
+            if answer_chunk is None:
+                continue
+
+            proc_map[c_name].add_fuse_history(
+                combined_query, answer_chunk.gist, nbr
+            )
+
+            if self.detailed_log is not None:
+                current_iteration = self.detailed_log['current_iteration']
+                fuse_info = {
+                    'from_processor': c_name,
+                    'to_processor': nbr,
+                    'query': answer_chunk.executor_content or combined_query,
+                    'answer': answer_chunk.gist,
+                }
+                current_iteration['fuse_phase'].append(fuse_info)
 
     @abstractmethod
     def forward(


### PR DESCRIPTION
Replace fuse_processor's nested for-loop of sequential ask(phase='fuse') calls with a three-pass structure:
1. collect (c_name, nbr, nbr_proc, combined_query) tasks in the original nested-for order
2. dispatch all ask calls concurrently via ThreadPoolExecutor, preserving submission order with [f.result() for f in futures] (not as_completed)
3. apply fuse_history / detailed_log side effects serially in the original order

Semantics are preserved: same filtering, same ask arguments, same append order to each processor's fuse_history, same detailed_log['fuse_phase'] order. Fuse-phase _build_executor_content does not read mutable processor state, so concurrent asks on the same processor are independent.

Per-iteration wall-clock drops from N*K*T to max(T) over all (c_name, nbr) pairs, aligning fusion with ask_processors and link_form which are already parallelized.

<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [ ] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
